### PR TITLE
travis: build all channels and a minimum version too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
-sudo: false
-language: rust
 dist: trusty
+language: rust
+rust:
+  - 1.26.0   # minimum supported toolchain
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
+
+script:
+  - cargo test

--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
-# GPT [![Build Status](https://travis-ci.org/Quyzi/gpt.svg?branch=master)](https://travis-ci.org/Quyzi/gpt)[![Docs](https://docs.rs/gpt/badge.svg)](https://docs.rs/gpt)
+# gpt
 
-Rust library for reading GPT headers and partition tables on disks and disk images.
+[![Build Status](https://travis-ci.org/Quyzi/gpt.svg?branch=master)](https://travis-ci.org/Quyzi/gpt)
+[![crates.io](https://img.shields.io/crates/v/gpt.svg)](https://crates.io/crates/gpt)
+![minimum rust 1.26](https://img.shields.io/badge/rust-1.26%2B-orange.svg)
+[![Documentation](https://docs.rs/gpt/badge.svg)](https://docs.rs/gpt)
+
+A pure-Rust library to work with GPT partition tables.
+
+`gpt` provides support for manipulating (R/W) GPT headers and partition
+tables. It supports raw disk devices as well as disk images.
+
+## Example
 
 ```rust
 extern crate gpt;
 use gpt::header::{Header, read_header};
 use gpt::partition::{Partition, read_partitions};
 
-let filename = "/dev/sda".to_string();
-let h = read_header(&filename).unwrap();
-let p = read_partitions(&filename, &h);
+fn inspect_disk() {
+    let filename = "/dev/sda";
+
+    let h = read_header(filename).unwrap();
+    println!("Disk header: {:#?}", h);
+
+    let p = read_partitions(filename, &h).unwrap();
+    println!("Partition layout: {:#?}", p);
+}
 ```


### PR DESCRIPTION
This updates travis to test all channels, and a pinned minimum version too (arbitrarily picked to match our other coreos projects). It also refreshes the README.