### PR TITLE
cargo: update dependencies to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://github.com/Quyzi/gpt"
 
 [dependencies]
 bitflags = "~1.0"
-byteorder = "~1.1"
-crc = "~1.5"
+byteorder = "~1.2"
+crc = "~1.8"
 itertools = "~0.7"
-lazy_static = "~0.2"
-log = "~0.3"
+lazy_static = "~1.0"
+log = "~0.4"
 uuid = { version = "~0.6", features = ["v4"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,7 @@ crc = "~1.5"
 itertools = "~0.7"
 lazy_static = "~0.2"
 log = "~0.3"
-simplelog = "~0.4"
 uuid = { version = "~0.6", features = ["v4"] }
+
+[dev-dependencies]
+simplelog = "~0.5"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -59,7 +59,7 @@ fn test_read_header() {
 
 #[test]
 fn test_write_header() {
-    let _ = SimpleLogger::init(log::LogLevelFilter::Trace, Config::default());
+    let _ = SimpleLogger::init(simplelog::LevelFilter::Trace, Config::default());
     {
         let data: [u8; 4096] = [0; 4096];
         println!("Creating blank header file for testing");


### PR DESCRIPTION
This updates all dependencies to their latest versions. `simplelog` is only used in tests, thus moved to `dev-dependencies` section.