### PR TITLE
disk: expose sector size setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ use gpt::header::{Header, read_header};
 use gpt::partition::{Partition, read_partitions};
 
 fn inspect_disk() {
-    let filename = "/dev/sda";
+    let lb_size = gpt::disk::DEFAULT_SECTOR_SIZE;
+    let diskpath = std::path::Path::new("/dev/sdz");
 
-    let h = read_header(filename).unwrap();
+    let hdr = header::read_header(diskpath, lb_size).unwrap();
     println!("Disk header: {:#?}", h);
 
-    let p = read_partitions(filename, &h).unwrap();
-    println!("Partition layout: {:#?}", p);
+    let pp = read_partitions(diskpath, &hdr, lb_size).unwrap();
+    println!("Partition layout: {:#?}", pp);
 }
 ```

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -25,6 +25,14 @@ impl Into<u64> for LogicalBlockSize {
 }
 
 /// Open and read a GPT disk, using default configuration options.
+///
+/// ## Example
+///
+/// ```rust,no_run
+/// let diskpath = std::path::Path::new("/dev/sda");
+/// let gpt_disk = gpt::disk::read_disk(diskpath).unwrap();
+/// println!("{:#?}", gpt_disk);
+/// ```
 pub fn read_disk(diskpath: &path::Path) -> io::Result<GptDisk> {
     let cfg = GptConfig::new();
     cfg.open(diskpath)

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -29,7 +29,7 @@ impl Into<u64> for LogicalBlockSize {
 /// ## Example
 ///
 /// ```rust,no_run
-/// let diskpath = std::path::Path::new("/dev/sda");
+/// let diskpath = std::path::Path::new("/dev/sdz");
 /// let gpt_disk = gpt::disk::read_disk(diskpath).unwrap();
 /// println!("{:#?}", gpt_disk);
 /// ```

--- a/src/header.rs
+++ b/src/header.rs
@@ -197,10 +197,16 @@ impl fmt::Display for Header {
 
 /// Read a GPT header from a given path.
 ///
+/// ## Example
+///
+/// ```rust,no_run
 /// use gpt::header::read_header;
 ///
-/// let h = read_header("/dev/sda")?;
+/// let lb_size = gpt::disk::DEFAULT_SECTOR_SIZE;
+/// let diskpath = std::path::Path::new("/dev/sdz");
 ///
+/// let h = read_header(diskpath, lb_size).unwrap();
+/// ```
 pub fn read_header(path: &Path, sector_size: disk::LogicalBlockSize) -> Result<Header> {
     let mut file = File::open(path)?;
     read_primary_header(&mut file, sector_size)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl GptConfig {
             .open(diskpath)?;
         let h1 = header::read_primary_header(&mut file, self.lb_size)?;
         let h2 = header::read_backup_header(&mut file, self.lb_size)?;
-        let table = partition::file_read_partitions(&mut file, &h1, self.lb_size.into())?;
+        let table = partition::file_read_partitions(&mut file, &h1, self.lb_size)?;
         let disk = GptDisk {
             config: self,
             file,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! extern crate gpt;
 //!
 //! fn inspect_disk() {
-//!     let diskpath = std::path::Path::new("/dev/sda");
+//!     let diskpath = std::path::Path::new("/dev/sdz");
 //!     let cfg = gpt::GptConfig::new().writable(false);
 //!
 //!     let disk = cfg.open(diskpath).expect("failed to open disk");

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -155,8 +155,8 @@ fn parse_parttype_guid(u: uuid::Uuid) -> PartitionType {
 /// use std::path::Path;
 ///
 /// let lb_size = disk::DEFAULT_SECTOR_SIZE;
-/// let diskpath = Path::new("/dev/sda");
-/// let mut hdr = header::read_header(diskpath, lb_size).unwrap();
+/// let diskpath = Path::new("/dev/sdz");
+/// let hdr = header::read_header(diskpath, lb_size).unwrap();
 /// let partitions = partition::read_partitions(diskpath, &hdr, lb_size).unwrap();
 /// println!("{:#?}", partitions);
 /// ```

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -1,0 +1,25 @@
+extern crate gpt;
+
+use gpt::disk;
+use std::path;
+
+#[test]
+fn test_gptconfig() {
+    let devnull = path::Path::new("/dev/null");
+    let cfg = {
+        let c1 = gpt::GptConfig::new();
+        let c2 = gpt::GptConfig::default();
+        assert_eq!(c1, c2);
+        c1
+    };
+
+    let lb_size = disk::LogicalBlockSize::Lb4096;
+    let disk = cfg.initialized(false)
+        .logical_block_size(lb_size)
+        .open(devnull)
+        .unwrap();
+    assert_eq!(*disk.logical_block_size(), lb_size);
+    assert_eq!(*disk.primary_header(), None);
+    assert_eq!(*disk.backup_header(), None);
+    assert!(disk.partitions().is_empty());
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -46,13 +46,13 @@ fn test_read_header() {
         name: "primary".to_string(),
     };
 
-    let filename = "tests/test_gpt";
-    let h = read_header(Path::new(filename), disk::DEFAULT_SECTOR_SIZE).unwrap();
+    let diskpath = Path::new("tests/test_gpt");
+    let h = read_header(diskpath, disk::DEFAULT_SECTOR_SIZE).unwrap();
 
     println!("header: {:?}", h);
     assert_eq!(h, expected_header);
 
-    let p = read_partitions(&filename, &h).unwrap();
+    let p = read_partitions(diskpath, &h, disk::DEFAULT_SECTOR_SIZE).unwrap();
     println!("Partitions: {:?}", p);
     assert_eq!(p[0], expected_partition);
 }
@@ -92,5 +92,5 @@ fn test_write_header() {
         flags: 0,
         name: "gpt test".to_string(),
     };
-    p.write(header_file, &h).unwrap();
+    p.write(header_file, &h, disk::DEFAULT_SECTOR_SIZE).unwrap();
 }


### PR DESCRIPTION
This exposes methods for customizing and retrieving sector size on a GPT disk object.

The PR also carries misc fixes/enhancements to docs and test that I happened to touch while looking around.