### PR TITLE
header: support writing backup header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ homepage = "https://github.com/Quyzi/gpt"
 bitflags = "~1.0"
 byteorder = "~1.2"
 crc = "~1.8"
-itertools = "~0.7"
 lazy_static = "~1.0"
 log = "~0.4"
 uuid = { version = "~0.6", features = ["v4"] }

--- a/src/header.rs
+++ b/src/header.rs
@@ -16,7 +16,7 @@ use disk;
 use partition;
 use uuid;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Header {
     /// EFI PART
     pub signature: String, // Offset  0. "EFI PART", 45h 46h 49h 20h 50h 41h 52h 54h
@@ -85,38 +85,60 @@ impl Header {
         Ok(hdr)
     }
 
-    /// Write the header to a location.  With a crc32 set to zero
-    /// this will set the crc32 after writing the Header out
+    /// Write the primary header.
+    ///
+    /// With a CRC32 set to zero this will set the crc32 after
+    /// writing the header out.
     pub fn write_primary(&self, file: &mut File, lb_size: disk::LogicalBlockSize) -> Result<usize> {
-        let mut bytes_written: usize = 0;
+        // This is the primary header. It must start before the backup one.
+        if self.current_lba >= self.backup_lba {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "primary header does not start before backup one",
+            ));
+        }
+        self.file_write_header(file, self.current_lba, lb_size)
+    }
 
+    /// Write the backup header.
+    ///
+    /// With a CRC32 set to zero this will set the crc32 after
+    /// writing the header out.
+    pub fn write_backup(&self, file: &mut File, lb_size: disk::LogicalBlockSize) -> Result<usize> {
+        // This is the backup header. It must start after the primary one.
+        if self.current_lba <= self.backup_lba {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "backup header does not start after primary one",
+            ));
+        }
+        self.file_write_header(file, self.current_lba, lb_size)
+    }
+
+    /// Write an header to an arbitrary LBA.
+    ///
+    /// With a CRC32 set to zero this will set the crc32 after
+    /// writing the header out.
+    fn file_write_header(
+        &self,
+        file: &mut File,
+        lba: u64,
+        lb_size: disk::LogicalBlockSize,
+    ) -> Result<usize> {
         // Build up byte array in memory
         let parts_checksum = partentry_checksum(file, self, lb_size)?;
         let bytes = self.as_bytes(None, Some(parts_checksum))?;
 
-        // Calculate the crc32 from the byte array
+        // Calculate the CRC32 from the byte array
         let checksum = calculate_crc32(&bytes)?;
 
         // Write it to disk in 1 shot
-        let start = self.current_lba
-            .checked_mul(lb_size.into())
-            .ok_or_else(|| Error::new(ErrorKind::Other, "primary header overflow - offset"))?;
+        let start = lba.checked_mul(lb_size.into())
+            .ok_or_else(|| Error::new(ErrorKind::Other, "header overflow - offset"))?;
         let _ = file.seek(SeekFrom::Start(start))?;
-        let csum_len = file.write(&self.as_bytes(Some(checksum), Some(parts_checksum))?)?;
-        bytes_written = bytes_written
-            .checked_add(csum_len)
-            .ok_or_else(|| Error::new(ErrorKind::Other, "primary header overflow - checksum"))?;
+        let len = file.write(&self.as_bytes(Some(checksum), Some(parts_checksum))?)?;
 
-        Ok(bytes_written)
-    }
-
-    // TODO: implement writing backup header too.
-    pub fn write_backup(&self, file: &mut File, lb_size: disk::LogicalBlockSize) -> Result<usize> {
-        let start = self.backup_lba
-            .checked_mul(lb_size.into())
-            .ok_or_else(|| Error::new(ErrorKind::Other, "backup header overflow - offset"))?;
-        let _ = file.seek(SeekFrom::Start(start))?;
-        Ok(0)
+        Ok(len)
     }
 
     fn as_bytes(&self, checksum: Option<u32>, parts_checksum: Option<u32>) -> Result<Vec<u8>> {
@@ -256,7 +278,7 @@ pub(crate) fn file_read_header(file: &mut File, offset: u64) -> Result<Header> {
         *crc_byte = 0;
     }
     let c = crc32::checksum_ieee(&hdr_crc);
-    trace!("hdr_crc: {:?}, h.crc32: {:?}", c, h.crc32);
+    trace!("header CRC32: {:#x} - computed CRC32: {:#x}", h.crc32, c);
     if crc32::checksum_ieee(&hdr_crc) == h.crc32 {
         Ok(h)
     } else {
@@ -265,7 +287,7 @@ pub(crate) fn file_read_header(file: &mut File, offset: u64) -> Result<Header> {
 }
 
 pub(crate) fn find_backup_lba(f: &mut File, sector_size: disk::LogicalBlockSize) -> Result<u64> {
-    trace!("Querying file size to find backup header location");
+    trace!("querying file size to find backup header location");
     let lb_size: u64 = sector_size.into();
     let m = f.metadata()?;
     if m.len() <= lb_size {
@@ -274,10 +296,15 @@ pub(crate) fn find_backup_lba(f: &mut File, sector_size: disk::LogicalBlockSize)
             "disk image too small for backup header",
         ));
     }
-    let backup_location = (m.len().saturating_sub(lb_size)) / lb_size;
-    trace!("Backup location: {:#x}", backup_location);
+    let bak_offset = m.len().saturating_sub(lb_size);
+    let bak_lba = bak_offset / lb_size;
+    trace!(
+        "backup header: LBA={}, bytes offset={}",
+        bak_lba,
+        bak_offset
+    );
 
-    Ok(backup_location)
+    Ok(bak_lba)
 }
 
 fn calculate_crc32(b: &[u8]) -> Result<u32> {

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,20 +1,15 @@
 //! GPT-header object and helper functions.
 
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use crc::{crc32, Hasher32};
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
 use std::path::Path;
+use uuid;
 
-extern crate crc;
-extern crate itertools;
-
-use self::itertools::Itertools;
-
-use self::crc::{crc32, Hasher32};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use disk;
 use partition;
-use uuid;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Header {
@@ -164,7 +159,6 @@ impl Header {
             Some(c) => buff.write_u32::<LittleEndian>(c)?,
             None => buff.write_u32::<LittleEndian>(0)?,
         };
-        trace!("Buffer: {:02x}", buff.iter().format(","));
         Ok(buff)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,20 +20,21 @@
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;
+extern crate crc;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
 extern crate uuid;
 
+use std::io::Write;
+use std::{fs, io, path};
+
 pub mod disk;
 pub mod header;
 pub mod mbr;
 pub mod partition;
 mod partition_types;
-
-use std::io::Write;
-use std::{fs, io, path};
 
 /// Configuration options to open a GPT disk.
 #[derive(Debug, Eq, PartialEq)]

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -3,22 +3,17 @@
 //! This module provides access to low-level primitives
 //! to work with GPT partitions.
 
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use crc::crc32;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
 use std::path::Path;
+use uuid;
 
 use disk;
 use header::{parse_uuid, partentry_checksum, Header};
-
-extern crate byteorder;
-extern crate crc;
-extern crate itertools;
-
-use self::byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use self::crc::crc32;
 use partition_types::PART_HASHMAP;
-use uuid;
 
 bitflags! {
     /// Partition entry attributes, defined for UEFI.

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -51,7 +51,5 @@ fn test_gptdisk_linux_01() {
     let p1_start = p1.bytes_start(*gdisk.logical_block_size()).unwrap();
     assert_eq!(p1_start, 0x22 * 512);
     let p1_len = p1.bytes_len(*gdisk.logical_block_size()).unwrap();
-    assert_eq!(p1_len, (0x3E - 0x22)* 512);
-
-
+    assert_eq!(p1_len, (0x3E - 0x22) * 512);
 }


### PR DESCRIPTION
This adds support for writing the backup header for a GPT disk.

It also performs a general cleanup of crate/use directives.