### PR TITLE
gpt: document all public APIs

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -11,9 +11,10 @@ use uuid;
 use disk;
 use partition;
 
+/// Header describing a GPT disk.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Header {
-    /// EFI PART
+    /// GPT header magic signature, hardcoded to "EFI PART".
     pub signature: String, // Offset  0. "EFI PART", 45h 46h 49h 20h 50h 41h 52h 54h
     /// 00 00 01 00
     pub revision: u32, // Offset  8

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //! }
 //! ```
 
+#![deny(missing_docs)]
+
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -18,9 +18,12 @@ use partition_types::PART_HASHMAP;
 bitflags! {
     /// Partition entry attributes, defined for UEFI.
     pub struct PartitionAttributes: u64 {
-        const PLATFORM   = 0;
-        const EFI        = 1;
-        const BOOTABLE   = (1 << 1);
+        /// Required platform partition.
+        const PLATFORM   = 1;
+        /// No Block-IO protocol.
+        const EFI        = (1 << 1);
+        /// Legacy-BIOS bootable partition.
+        const BOOTABLE   = (1 << 2);
     }
 }
 
@@ -138,8 +141,11 @@ impl Partition {
 /// Partition type, with optional description.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PartitionType {
+    /// Type-GUID for a GPT partition.
     pub guid: uuid::Uuid,
+    /// Optional well-known OS label for this type-GUID.
     pub os: String,
+    /// Optional well-known description label for this type-GUID.
     pub description: String,
 }
 


### PR DESCRIPTION
This adds documentation to all public items and turns on warning to
make sure all future API will come with docstrings.