### PR TITLE
Partition type macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 bitflags = "~1.0"
 byteorder = { version = "~1.2", features = ["i128"] }
 crc = "~1.8"
-lazy_static = "~1.2"
 log = "~0.4"
 uuid = { version = "~0.7", features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpt"
-version = "0.3.1"
+version = "0.4.0"
 description = "A pure-Rust library to work with GPT partition tables."
 documentation = "https://docs.rs/gpt"
 authors = ["Chris Ober <obercgit@gmail.com>", "Chris Holcombe <xfactor973@gmail.com>", "Luca Bruno <lucab@debian.org>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 #![deny(missing_docs)]
 
 use bitflags;
-use lazy_static;
 use log::*;
 use std::cmp::Ordering;
 use std::io::Write;
@@ -30,7 +29,7 @@ pub mod disk;
 pub mod header;
 pub mod mbr;
 pub mod partition;
-mod partition_types;
+pub mod partition_types;
 
 /// Configuration options to open a GPT disk.
 #[derive(Debug, Eq, PartialEq)]
@@ -143,7 +142,7 @@ impl GptDisk {
         &mut self,
         name: &str,
         size: usize,
-        part_type: partition::PartitionType,
+        part_type: partition_types::Type,
         flags: u64,
     ) -> io::Result<()> {
         self.sort_partitions();

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -91,7 +91,7 @@ macro_rules! partition_types {
     (
         $(
             $(#[$docs:meta])*
-            ($upcase:ident, $guid:expr, $os:expr);
+            ($upcase:ident, $guid:expr, $os:expr)$(,)*
         )+
     ) => {
         $(
@@ -101,6 +101,18 @@ macro_rules! partition_types {
                 os: $os,
             };
         )+
+        
+        impl FromStr for Type {
+            type Err = String;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    $(
+                        $guid => Ok(Type { guid: $guid, os: $os }),
+                    )+
+                    _ => Err("Invalid.".to_string()),
+                }
+            }
+        }
     }
 }
 
@@ -112,127 +124,6 @@ fn test_partition_fromstr() {
     assert_eq!(t, LINUX_FS);
 }
 
-impl FromStr for Type {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        debug!("looking up partition type guid {}", s);
-        match s {
-            "00000000-0000-0000-0000-000000000000" => Ok(UNUSED),
-            "024DEE41-33E7-11D3-9D69-0008C781F39F" => Ok(MBR),
-            "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" => Ok(EFI),
-            "21686148-6449-6E6F-744E-656564454649" => Ok(BIOS),
-            "D3BFE2DE-3DAF-11DF-BA40-E3A556D89593" => Ok(FLASH),
-            "F4019732-066E-4E12-8273-346C5641494F" => Ok(SONY_BOOT),
-            "BFBFAFE7-A34F-448A-9A5B-6213EB736C22" => Ok(LENOVO_BOOT),
-            "E3C9E316-0B5C-4DB8-817D-F92DF00215AE" => Ok(MICROSOFT_RESERVED),
-            "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7" => Ok(BASIC),
-            "5808C8AA-7E8F-42E0-85D2-E1E90434CFB3" => Ok(WINDOWS_METADATA),
-            "AF9B60A0-1431-4F62-BC68-3311714A69AD" => Ok(WINDOWS_DATA),
-            "DE94BBA4-06D1-4D40-A16A-BFD50179D6AC" => Ok(WINDOWS_RECOVERY),
-            "37AFFC90-EF7D-4E96-91C3-2D7AE055B174" => Ok(WINDOWS_PARALLEL),
-            "E75CAF8F-F680-4CEE-AFA3-B001E56EFC2D" => Ok(WINDOWS_STORAGESPACES),
-            "75894C1E-3AEB-11D3-B7C1-7B03A0000000" => Ok(HPUNIX_DATA),
-            "E2A1E728-32E3-11D6-A682-7B03A0000000" => Ok(HPUNIX_SERVICE),
-            "0FC63DAF-8483-4772-8E79-3D69D8477DE4" => Ok(LINUX_FS),
-            "A19D880F-05FC-4D3B-A006-743F0F84911E" => Ok(LINUX_RAID),
-            "44479540-F297-41B2-9AF7-D131D5F0458A" => Ok(LINUX_ROOT_X86),
-            "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709" => Ok(LINUX_ROOT_X64),
-            "69DAD710-2CE4-4E3C-B16C-21A1D49ABED3" => Ok(LINUX_ROOT_ARM_32),
-            "B921B045-1DF0-41C3-AF44-4C6F280D3FAE" => Ok(LINUX_ROOT_ARM_64),
-            "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F" => Ok(LINUX_SWAP),
-            "E6D6D379-F507-44C2-A23C-238F2A3DF928" => Ok(LINUX_LVM),
-            "933AC7E1-2EB4-4F13-B844-0E14E2AEF915" => Ok(LINUX_HOME),
-            "3B8F8425-20E0-4F3B-907F-1A25A76F98E8" => Ok(LINUX_SRV),
-            "7FFEC5C9-2D00-49B7-8941-3EA10A5586B7" => Ok(LINUX_DMCRYPT),
-            "CA7D7CCB-63ED-4C53-861C-1742536059CC" => Ok(LINUX_LUKS),
-            "8DA63339-0007-60C0-C436-083AC8230908" => Ok(LINUX_RESERVED),
-            "516E7CB4-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_DATA),
-            "83BD6B9D-7F41-11DC-BE0B-001560B84F0F" => Ok(FREEBSD_BOOT),
-            "516E7CB5-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_SWAP),
-            "516E7CB6-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_UFS),
-            "516E7CB8-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_VINIUM),
-            "516E7CBA-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_ZFS),
-            "48465300-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_HFSPLUS),
-            "55465300-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_UFS),
-            "6A898CC3-1DD2-11B2-99A6-080020736631" => Ok(MACOS_ZFS),
-            "52414944-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_RAID),
-            "52414944-5F4F-11AA-AA11-00306543ECAC" => Ok(MACOS_RAID_OFFLINE),
-            "426F6F74-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_RECOVERY),
-            "4C616265-6C00-11AA-AA11-00306543ECAC" => Ok(MACOS_LABEL),
-            "5265636F-7665-11AA-AA11-00306543ECAC" => Ok(MACOS_TV_RECOVERY),
-            "53746F72-6167-11AA-AA11-00306543ECAC" => Ok(MACOS_CORE),
-            "B6FA30DA-92D2-4A9A-96F1-871EC6486200" => Ok(MACOS_SOFTRAID_STATUS),
-            "2E313465-19B9-463F-8126-8A7993773801" => Ok(MACOS_SOFTRAID_SCRATCH),
-            "FA709C7E-65B1-4593-BFD5-E71D61DE9B02" => Ok(MACOS_SOFTRAID_VOLUME),
-            "BBBA6DF5-F46F-4A89-8F59-8765B2727503" => Ok(MACOS_SOFTRAID_CACHE),
-            "6A82CB45-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_BOOT),
-            "6A85CF4D-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_ROOT),
-            "6A87C46F-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_SWAP),
-            "6A8B642B-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_BACKUP),
-            //"6A898CC3-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_USR),
-            "6A8EF2E9-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_VAR),
-            "6A90BA39-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_HOME),
-            "6A9283A5-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_ALT),
-            "6A945A3B-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED1),
-            "6A9630D1-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED2),
-            "6A980767-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED3),
-            "6A96237F-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED4),
-            "6A8D2AC7-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED5),
-            "49F48D32-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_SWAP),
-            "49F48D5A-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_FFS),
-            "49F48D82-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_LFS),
-            "49F48DAA-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_RAID),
-            "2DB519C4-B10F-11DC-B99B-0019D1879648" => Ok(NETBSD_CONCAT),
-            "2DB519EC-B10F-11DC-B99B-0019D1879648" => Ok(NETBSD_ENCRYPTED),
-            "FE3A2A5D-4F32-41A7-B725-ACCC3285A309" => Ok(CHROME_KERNEL),
-            "3CB8E202-3B7E-47DD-8A3C-7FF2A13CFCEC" => Ok(CHROME_ROOTFS),
-            "2E0A753D-9E48-43B0-8337-B15192CB1B5E" => Ok(CHROME_FUTURE),
-            "5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6" => Ok(COREOS_USR),
-            "3884DD41-8582-4404-B9A8-E9B84F2DF50E" => Ok(COREOS_ROOTFS_RESIZE),
-            "C95DC21A-DF0E-4340-8D7B-26CBFA9A03E0" => Ok(COREOS_OEM),
-            "BE9067B9-EA49-4F15-B4F6-F36F8C9E1818" => Ok(COREOS_ROOT_RAID),
-            "42465331-3BA3-10F1-802A-4861696B7521" => Ok(HAIKU_BFS),
-            "85D5E45E-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_BOOT),
-            "85D5E45A-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_DATA),
-            "85D5E45B-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_SWAP),
-            "0394EF8B-237E-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_UFS),
-            "85D5E45C-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_VINIUM),
-            "85D5E45D-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_ZFS),
-            "45B0969E-9B03-4F30-B4C6-B4B80CEFF106" => Ok(CEPH_JOURNAL),
-            "45B0969E-9B03-4F30-B4C6-5EC00CEFF106" => Ok(CEPH_CRYPT_JOURNAL),
-            "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D" => Ok(CEPH_OSD),
-            "4FBD7E29-9D25-41B8-AFD0-5EC00CEFF05D" => Ok(CEPH_CRYPT),
-            "89C57F98-2FE5-4DC0-89C1-F3AD0CEFF2BE" => Ok(CEPH_DISK_CREATION),
-            "89C57F98-2FE5-4DC0-89C1-5EC00CEFF2BE" => Ok(CEPH_CRYPT_CREATION),
-            "824CC7A0-36A8-11E3-890A-952519AD3F61" => Ok(OPENBSD_DATA),
-            "CEF5A9AD-73BC-4601-89F3-CDEEEEE321A1" => Ok(QNX_FS),
-            "C91818F9-8025-47AF-89D2-F030D7000C2C" => Ok(PLAN9_PART),
-            "9D275380-40AD-11DB-BF97-000C2911D1B8" => Ok(VMWARE_COREDUMP),
-            "AA31E02A-400F-11DB-9590-000C2911D1B8" => Ok(VMWARE_VMFS),
-            "9198EFFC-31C0-11DB-8F78-000C2911D1B8" => Ok(VMWARE_RESERVED),
-            "2568845D-2332-4675-BC39-8FA5A4748D15" => Ok(ANDROID_BOOTLOADER),
-            "114EAFFE-1552-4022-B26E-9B053604CF84" => Ok(ANDROID_BOOTLOADER2),
-            "49A4D17F-93A3-45C1-A0DE-F50B2EBE2599" => Ok(ANDROID_BOOT),
-            "4177C722-9E92-4AAB-8644-43502BFD5506" => Ok(ANDROID_RECOVERY),
-            "EF32A33B-A409-486C-9141-9FFB711F6266" => Ok(ANDROID_MISC),
-            "20AC26BE-20B7-11E3-84C5-6CFDB94711E9" => Ok(ANDROID_META),
-            "38F428E6-D326-425D-9140-6E0EA133647C" => Ok(ANDROID_SYSTEM),
-            "A893EF21-E428-470A-9E55-0668FD91A2D9" => Ok(ANDROID_CACHE),
-            "DC76DDA9-5AC1-491C-AF42-A82591580C0D" => Ok(ANDROID_DATA),
-            "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1" => Ok(ANDROID_PERSISTENT),
-            "8F68CC74-C5E5-48DA-BE91-A0C8C15E9C80" => Ok(ANDROID_FACTORY),
-            "767941D0-2085-11E3-AD3B-6CFDB94711E9" => Ok(ANDROID_FASTBOOT),
-            "AC6D7924-EB71-4DF8-B48D-E267B27148FF" => Ok(ANDROID_OEM),
-            "7412F7D5-A156-4B13-81DC-867174929325" => Ok(ONIE_BOOT),
-            "D4E6E2CD-4469-46F3-B5CB-1BFF57AFC149" => Ok(ONIE_CONFIG),
-            "9E1A2D38-C612-4316-AA26-8B49521E5A8B" => Ok(PPC_BOOT),
-            "BC13C2FF-59E6-4262-A352-B275FD6F7172" => Ok(FREEDESK_BOOT),
-            "734E5AFE-F61A-11E6-BC64-92361F002671" => Ok(ATARI_DATA),
-            _ => Err("Unknown Partition Type".to_string()),
-        }
-    }
-}
-
 impl Type {
     /// Lookup a partition type by uuid
     pub fn from_uuid(u: &uuid::Uuid) -> Result<Self, String> {
@@ -242,227 +133,238 @@ impl Type {
     }
 }
 
+// partition_types! {
+//     /// unused
+//     (UNUSED, "00000000-0000-0000-0000-000000000000", OperatingSystem::None),
+//     /// MBR Partition Scheme
+//     (MBR, "024DEE41-33E7-11D3-9D69-0008C781F39F", OperatingSystem::None),
+//     /// EFI System Partition
+//     (EFI, "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", OperatingSystem::None),
+//     /// BIOS Boot Partition
+//     (BIOS, "21686148-6449-6E6F-744E-656564454649", OperatingSystem::None),
+// }
+
 partition_types! {
     /// unused
-    (UNUSED, "00000000-0000-0000-0000-000000000000", OperatingSystem::None);
+    (UNUSED, "00000000-0000-0000-0000-000000000000", OperatingSystem::None),
     /// MBR Partition Scheme
-    (MBR, "024DEE41-33E7-11D3-9D69-0008C781F39F", OperatingSystem::None);
+    (MBR, "024DEE41-33E7-11D3-9D69-0008C781F39F", OperatingSystem::None),
     /// EFI System Partition
-    (EFI, "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", OperatingSystem::None);
+    (EFI, "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", OperatingSystem::None),
     /// BIOS Boot Partition
-    (BIOS, "21686148-6449-6E6F-744E-656564454649", OperatingSystem::None);
+    (BIOS, "21686148-6449-6E6F-744E-656564454649", OperatingSystem::None),
     /// Intel Fast Flash (iFFS) Partition
-    (FLASH, "D3BFE2DE-3DAF-11DF-BA40-E3A556D89593",OperatingSystem::None);
+    (FLASH, "D3BFE2DE-3DAF-11DF-BA40-E3A556D89593",OperatingSystem::None),
     /// Sony Boot Partition
-    (SONY_BOOT, "F4019732-066E-4E12-8273-346C5641494F", OperatingSystem::None);
+    (SONY_BOOT, "F4019732-066E-4E12-8273-346C5641494F", OperatingSystem::None),
     /// Lenovo Boot Partition
-    (LENOVO_BOOT, "BFBFAFE7-A34F-448A-9A5B-6213EB736C22", OperatingSystem::None);
+    (LENOVO_BOOT, "BFBFAFE7-A34F-448A-9A5B-6213EB736C22", OperatingSystem::None),
     /// Microsoft Reserved Partition
-    (MICROSOFT_RESERVED, "E3C9E316-0B5C-4DB8-817D-F92DF00215AE", OperatingSystem::Windows);
+    (MICROSOFT_RESERVED, "E3C9E316-0B5C-4DB8-817D-F92DF00215AE", OperatingSystem::Windows),
     /// Basic Data Partition
-    (BASIC, "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7", OperatingSystem::Windows);
+    (BASIC, "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7", OperatingSystem::Windows),
     /// Logical Disk Manager Metadata Partition
-    (WINDOWS_METADATA, "5808C8AA-7E8F-42E0-85D2-E1E90434CFB3", OperatingSystem::Windows);
+    (WINDOWS_METADATA, "5808C8AA-7E8F-42E0-85D2-E1E90434CFB3", OperatingSystem::Windows),
     /// Logical Disk Manager Data Partition
-    (WINDOWS_DATA, "AF9B60A0-1431-4F62-BC68-3311714A69AD", OperatingSystem::Windows);
+    (WINDOWS_DATA, "AF9B60A0-1431-4F62-BC68-3311714A69AD", OperatingSystem::Windows),
     /// Windows Recovery Environment
-    (WINDOWS_RECOVERY, "DE94BBA4-06D1-4D40-A16A-BFD50179D6AC", OperatingSystem::Windows);
+    (WINDOWS_RECOVERY, "DE94BBA4-06D1-4D40-A16A-BFD50179D6AC", OperatingSystem::Windows),
     /// IBM General Parallel File System Partition
-    (WINDOWS_PARALLEL, "37AFFC90-EF7D-4E96-91C3-2D7AE055B174", OperatingSystem::Windows);
+    (WINDOWS_PARALLEL, "37AFFC90-EF7D-4E96-91C3-2D7AE055B174", OperatingSystem::Windows),
     /// Storage Spaces Partition
-    (WINDOWS_STORAGESPACES, "E75CAF8F-F680-4CEE-AFA3-B001E56EFC2D", OperatingSystem::Windows);
+    (WINDOWS_STORAGESPACES, "E75CAF8F-F680-4CEE-AFA3-B001E56EFC2D", OperatingSystem::Windows),
     /// HP Unix Data Partition
-    (HPUNIX_DATA, "75894C1E-3AEB-11D3-B7C1-7B03A0000000", OperatingSystem::HpUnix);
+    (HPUNIX_DATA, "75894C1E-3AEB-11D3-B7C1-7B03A0000000", OperatingSystem::HpUnix),
     /// HP Unix Service Partition
-    (HPUNIX_SERVICE, "E2A1E728-32E3-11D6-A682-7B03A0000000", OperatingSystem::HpUnix);
+    (HPUNIX_SERVICE, "E2A1E728-32E3-11D6-A682-7B03A0000000", OperatingSystem::HpUnix),
     /// Linux Filesystem Data
-    (LINUX_FS, "0FC63DAF-8483-4772-8E79-3D69D8477DE4", OperatingSystem::Linux);
+    (LINUX_FS, "0FC63DAF-8483-4772-8E79-3D69D8477DE4", OperatingSystem::Linux),
     /// Linux RAID Partition
-    (LINUX_RAID, "A19D880F-05FC-4D3B-A006-743F0F84911E", OperatingSystem::Linux);
+    (LINUX_RAID, "A19D880F-05FC-4D3B-A006-743F0F84911E", OperatingSystem::Linux),
     /// Linux Root Partition (x86)
-    (LINUX_ROOT_X86, "44479540-F297-41B2-9AF7-D131D5F0458A", OperatingSystem::Linux);
+    (LINUX_ROOT_X86, "44479540-F297-41B2-9AF7-D131D5F0458A", OperatingSystem::Linux),
     /// Linux Root Partition (x86-64)
-    (LINUX_ROOT_X64, "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709", OperatingSystem::Linux);
+    (LINUX_ROOT_X64, "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709", OperatingSystem::Linux),
     /// Linux Root Partition (32-bit ARM)
-    (LINUX_ROOT_ARM_32, "69DAD710-2CE4-4E3C-B16C-21A1D49ABED3", OperatingSystem::Linux);
+    (LINUX_ROOT_ARM_32, "69DAD710-2CE4-4E3C-B16C-21A1D49ABED3", OperatingSystem::Linux),
     /// Linux Root Partition (64-bit ARM/AArch64)
-    (LINUX_ROOT_ARM_64, "B921B045-1DF0-41C3-AF44-4C6F280D3FAE", OperatingSystem::Linux);
+    (LINUX_ROOT_ARM_64, "B921B045-1DF0-41C3-AF44-4C6F280D3FAE", OperatingSystem::Linux),
     /// Linux Swap Partition
-    (LINUX_SWAP, "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F", OperatingSystem::Linux);
+    (LINUX_SWAP, "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F", OperatingSystem::Linux),
     /// Linux Logical Volume Manager Partition
-    (LINUX_LVM, "E6D6D379-F507-44C2-A23C-238F2A3DF928", OperatingSystem::Linux);
+    (LINUX_LVM, "E6D6D379-F507-44C2-A23C-238F2A3DF928", OperatingSystem::Linux),
     /// Linux /home Partition
-    (LINUX_HOME, "933AC7E1-2EB4-4F13-B844-0E14E2AEF915", OperatingSystem::Linux);
+    (LINUX_HOME, "933AC7E1-2EB4-4F13-B844-0E14E2AEF915", OperatingSystem::Linux),
     /// Linux /srv (Server Data) Partition
-    (LINUX_SRV, "3B8F8425-20E0-4F3B-907F-1A25A76F98E8", OperatingSystem::Linux);
+    (LINUX_SRV, "3B8F8425-20E0-4F3B-907F-1A25A76F98E8", OperatingSystem::Linux),
     /// Linux Plain dm-crypt Partition
-    (LINUX_DMCRYPT, "7FFEC5C9-2D00-49B7-8941-3EA10A5586B7", OperatingSystem::Linux);
+    (LINUX_DMCRYPT, "7FFEC5C9-2D00-49B7-8941-3EA10A5586B7", OperatingSystem::Linux),
     /// Linux LUKS Partition
-    (LINUX_LUKS, "CA7D7CCB-63ED-4C53-861C-1742536059CC", OperatingSystem::Linux);
+    (LINUX_LUKS, "CA7D7CCB-63ED-4C53-861C-1742536059CC", OperatingSystem::Linux),
     /// Linux Reserved
-    (LINUX_RESERVED, "8DA63339-0007-60C0-C436-083AC8230908", OperatingSystem::Linux);
+    (LINUX_RESERVED, "8DA63339-0007-60C0-C436-083AC8230908", OperatingSystem::Linux),
     /// FreeBSD Data Partition
-    (FREEBSD_DATA, "516E7CB4-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    (FREEBSD_DATA, "516E7CB4-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd),
     /// FreeBSD Boot Partition
-    (FREEBSD_BOOT, "83BD6B9D-7F41-11DC-BE0B-001560B84F0F", OperatingSystem::FreeBsd);
+    (FREEBSD_BOOT, "83BD6B9D-7F41-11DC-BE0B-001560B84F0F", OperatingSystem::FreeBsd),
     /// FreeBSD Swap Partition
-    (FREEBSD_SWAP, "516E7CB5-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    (FREEBSD_SWAP, "516E7CB5-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd),
     /// FreeBSD Unix File System (UFS) Partition
-    (FREEBSD_UFS, "516E7CB6-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    (FREEBSD_UFS, "516E7CB6-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd),
     /// FreeBSD Vinium Volume Manager Partition
-    (FREEBSD_VINIUM, "516E7CB8-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    (FREEBSD_VINIUM, "516E7CB8-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd),
     /// FreeBSD ZFS Partition
-    (FREEBSD_ZFS, "516E7CBA-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    (FREEBSD_ZFS, "516E7CBA-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd),
     /// Apple Hierarchical File System Plus (HFS+) Partition
-    (MACOS_HFSPLUS, "48465300-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_HFSPLUS, "48465300-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// Apple UFS
-    (MACOS_UFS, "55465300-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_UFS, "55465300-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// Apple ZFS
-    (MACOS_ZFS, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::MacOs);
+    (MACOS_ZFS, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::MacOs),
     /// Apple RAID Partition
-    (MACOS_RAID, "52414944-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_RAID, "52414944-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// APple RAID Partition, offline
-    (MACOS_RAID_OFFLINE, "52414944-5F4F-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_RAID_OFFLINE, "52414944-5F4F-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// Apple Boot Partition (Recovery HD)
-    (MACOS_RECOVERY, "426F6F74-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_RECOVERY, "426F6F74-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// Apple Label
-    (MACOS_LABEL, "4C616265-6C00-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_LABEL, "4C616265-6C00-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// Apple TV Recovery Partition
-    (MACOS_TV_RECOVERY, "5265636F-7665-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_TV_RECOVERY, "5265636F-7665-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// Apple Core Storage Partition
-    (MACOS_CORE, "53746F72-6167-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    (MACOS_CORE, "53746F72-6167-11AA-AA11-00306543ECAC", OperatingSystem::MacOs),
     /// Apple SoftRAID_Status
-    (MACOS_SOFTRAID_STATUS, "B6FA30DA-92D2-4A9A-96F1-871EC6486200", OperatingSystem::MacOs);
+    (MACOS_SOFTRAID_STATUS, "B6FA30DA-92D2-4A9A-96F1-871EC6486200", OperatingSystem::MacOs),
     /// Apple SoftRAID_Scratch
-    (MACOS_SOFTRAID_SCRATCH, "2E313465-19B9-463F-8126-8A7993773801", OperatingSystem::MacOs);
+    (MACOS_SOFTRAID_SCRATCH, "2E313465-19B9-463F-8126-8A7993773801", OperatingSystem::MacOs),
     /// Apple SoftRAID_Volume
-    (MACOS_SOFTRAID_VOLUME, "FA709C7E-65B1-4593-BFD5-E71D61DE9B02", OperatingSystem::MacOs);
+    (MACOS_SOFTRAID_VOLUME, "FA709C7E-65B1-4593-BFD5-E71D61DE9B02", OperatingSystem::MacOs),
     /// Apple SOftRAID_Cache
-    (MACOS_SOFTRAID_CACHE, "BBBA6DF5-F46F-4A89-8F59-8765B2727503", OperatingSystem::MacOs);
+    (MACOS_SOFTRAID_CACHE, "BBBA6DF5-F46F-4A89-8F59-8765B2727503", OperatingSystem::MacOs),
     /// Solaris Boot Partition
-    (SOLARIS_BOOT, "6A82CB45-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_BOOT, "6A82CB45-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Root Partition
-    (SOLARIS_ROOT, "6A85CF4D-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_ROOT, "6A85CF4D-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Swap Partition
-    (SOLARIS_SWAP, "6A87C46F-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_SWAP, "6A87C46F-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Backup Partition
-    (SOLARIS_BACKUP, "6A8B642B-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_BACKUP, "6A8B642B-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// /Solaris usr Partition
-    (SOLARIS_USR, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_USR, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris /var Partition
-    (SOLARIS_VAR, "6A8EF2E9-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_VAR, "6A8EF2E9-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris /home Partition
-    (SOLARIS_HOME, "6A90BA39-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_HOME, "6A90BA39-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Alternate Sector
-    (SOLARIS_ALT, "6A9283A5-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_ALT, "6A9283A5-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Reserved
-    (SOLARIS_RESERVED1, "6A945A3B-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_RESERVED1, "6A945A3B-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Reserved
-    (SOLARIS_RESERVED2, "6A9630D1-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_RESERVED2, "6A9630D1-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Reserved
-    (SOLARIS_RESERVED3, "6A980767-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_RESERVED3, "6A980767-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Reserved
-    (SOLARIS_RESERVED4, "6A96237F-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_RESERVED4, "6A96237F-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Reserved
-    (SOLARIS_RESERVED5, "6A8D2AC7-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    (SOLARIS_RESERVED5, "6A8D2AC7-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// NetBSD Swap Partition
-    (NETBSD_SWAP, "49F48D32-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    (NETBSD_SWAP, "49F48D32-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd),
     /// NetBSD FFS Partition
-    (NETBSD_FFS, "49F48D5A-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    (NETBSD_FFS, "49F48D5A-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd),
     /// NetBSD LFS Partition
-    (NETBSD_LFS, "49F48D82-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    (NETBSD_LFS, "49F48D82-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd),
     /// NetBSD RAID Partition
-    (NETBSD_RAID, "49F48DAA-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    (NETBSD_RAID, "49F48DAA-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd),
     /// NetBSD Concatenated Partition
-    (NETBSD_CONCAT, "2DB519C4-B10F-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    (NETBSD_CONCAT, "2DB519C4-B10F-11DC-B99B-0019D1879648", OperatingSystem::NetBsd),
     /// NetBSD Encrypted Partition
-    (NETBSD_ENCRYPTED, "2DB519EC-B10F-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    (NETBSD_ENCRYPTED, "2DB519EC-B10F-11DC-B99B-0019D1879648", OperatingSystem::NetBsd),
     /// ChromeOS Kernel
-    (CHROME_KERNEL, "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", OperatingSystem::Chrome);
+    (CHROME_KERNEL, "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", OperatingSystem::Chrome),
     /// ChromeOS rootfs
-    (CHROME_ROOTFS, "3CB8E202-3B7E-47DD-8A3C-7FF2A13CFCEC",OperatingSystem::Chrome);
+    (CHROME_ROOTFS, "3CB8E202-3B7E-47DD-8A3C-7FF2A13CFCEC",OperatingSystem::Chrome),
     /// ChromeOS Future Use
-    (CHROME_FUTURE, "2E0A753D-9E48-43B0-8337-B15192CB1B5E",OperatingSystem::Chrome);
+    (CHROME_FUTURE, "2E0A753D-9E48-43B0-8337-B15192CB1B5E",OperatingSystem::Chrome),
     /// CoreOS /usr partition (coreos-usr)
-    (COREOS_USR, "5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6", OperatingSystem::CoreOs);
+    (COREOS_USR, "5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6", OperatingSystem::CoreOs),
     /// CoreOS Resizable rootfs (coreos-resize)
-    (COREOS_ROOTFS_RESIZE, "3884DD41-8582-4404-B9A8-E9B84F2DF50E", OperatingSystem::CoreOs);
+    (COREOS_ROOTFS_RESIZE, "3884DD41-8582-4404-B9A8-E9B84F2DF50E", OperatingSystem::CoreOs),
     /// CoreOS OEM customizations (coreos-reserved)
-    (COREOS_OEM, "C95DC21A-DF0E-4340-8D7B-26CBFA9A03E0", OperatingSystem::CoreOs);
+    (COREOS_OEM, "C95DC21A-DF0E-4340-8D7B-26CBFA9A03E0", OperatingSystem::CoreOs),
     /// CoreOS Root filesystem on RAID (coreos-root-raid)
-    (COREOS_ROOT_RAID, "BE9067B9-EA49-4F15-B4F6-F36F8C9E1818", OperatingSystem::CoreOs);
+    (COREOS_ROOT_RAID, "BE9067B9-EA49-4F15-B4F6-F36F8C9E1818", OperatingSystem::CoreOs),
     /// Haiku BFS
-    (HAIKU_BFS, "42465331-3BA3-10F1-802A-4861696B7521", OperatingSystem::Haiku);
+    (HAIKU_BFS, "42465331-3BA3-10F1-802A-4861696B7521", OperatingSystem::Haiku),
     /// MidnightBSD Boot Partition
-    (MIDNIGHT_BOOT, "85D5E45E-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    (MIDNIGHT_BOOT, "85D5E45E-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd),
     /// MidnightBSD Data Partition
-    (MIDNIGHT_DATA, "85D5E45A-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    (MIDNIGHT_DATA, "85D5E45A-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd),
     /// MidnightBSD Swap Partition
-    (MIDNIGHT_SWAP, "85D5E45B-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    (MIDNIGHT_SWAP, "85D5E45B-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd),
     /// MidnightBSD Unix File System (UFS) Partition
-    (MIDNIGHT_UFS, "0394EF8B-237E-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    (MIDNIGHT_UFS, "0394EF8B-237E-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd),
     /// MidnightBSD Vinium Volume Manager Partition
-    (MIDNIGHT_VINIUM, "85D5E45C-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    (MIDNIGHT_VINIUM, "85D5E45C-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd),
     /// MidnightBSD ZFS Partition
-    (MIDNIGHT_ZFS, "85D5E45D-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    (MIDNIGHT_ZFS, "85D5E45D-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd),
     /// Ceph Journal
-    (CEPH_JOURNAL, "45B0969E-9B03-4F30-B4C6-B4B80CEFF106", OperatingSystem::Ceph);
+    (CEPH_JOURNAL, "45B0969E-9B03-4F30-B4C6-B4B80CEFF106", OperatingSystem::Ceph),
     /// Ceph dm-crypt Encryted Journal
-    (CEPH_CRYPT_JOURNAL, "45B0969E-9B03-4F30-B4C6-5EC00CEFF106", OperatingSystem::Ceph);
+    (CEPH_CRYPT_JOURNAL, "45B0969E-9B03-4F30-B4C6-5EC00CEFF106", OperatingSystem::Ceph),
     /// Ceph OSD
-    (CEPH_OSD, "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D", OperatingSystem::Ceph);
+    (CEPH_OSD, "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D", OperatingSystem::Ceph),
     /// Ceph dm-crypt OSD
-    (CEPH_CRYPT, "4FBD7E29-9D25-41B8-AFD0-5EC00CEFF05D", OperatingSystem::Ceph);
+    (CEPH_CRYPT, "4FBD7E29-9D25-41B8-AFD0-5EC00CEFF05D", OperatingSystem::Ceph),
     /// Ceph Disk In Creation
-    (CEPH_DISK_CREATION, "89C57F98-2FE5-4DC0-89C1-F3AD0CEFF2BE", OperatingSystem::Ceph);
+    (CEPH_DISK_CREATION, "89C57F98-2FE5-4DC0-89C1-F3AD0CEFF2BE", OperatingSystem::Ceph),
     /// Ceph dm-crypt Disk In Creation
-    (CEPH_CRYPT_CREATION, "89C57F98-2FE5-4DC0-89C1-5EC00CEFF2BE", OperatingSystem::Ceph);
+    (CEPH_CRYPT_CREATION, "89C57F98-2FE5-4DC0-89C1-5EC00CEFF2BE", OperatingSystem::Ceph),
     /// OpenBSD Data Partition
-    (OPENBSD_DATA, "824CC7A0-36A8-11E3-890A-952519AD3F61", OperatingSystem::OpenBsd);
+    (OPENBSD_DATA, "824CC7A0-36A8-11E3-890A-952519AD3F61", OperatingSystem::OpenBsd),
     /// QNX Power-safe (QNX6) File System
-    (QNX_FS, "CEF5A9AD-73BC-4601-89F3-CDEEEEE321A1", OperatingSystem::QNX);
+    (QNX_FS, "CEF5A9AD-73BC-4601-89F3-CDEEEEE321A1", OperatingSystem::QNX),
     /// Plan 9 Partition
-    (PLAN9_PART, "C91818F9-8025-47AF-89D2-F030D7000C2C", OperatingSystem::Plan9);
+    (PLAN9_PART, "C91818F9-8025-47AF-89D2-F030D7000C2C", OperatingSystem::Plan9),
     /// VMWare vmkcore (coredump partition)
-    (VMWARE_COREDUMP, "9D275380-40AD-11DB-BF97-000C2911D1B8", OperatingSystem::VmWare);
+    (VMWARE_COREDUMP, "9D275380-40AD-11DB-BF97-000C2911D1B8", OperatingSystem::VmWare),
     /// VMWare VMFS Filesystem Partition
-    (VMWARE_VMFS, "AA31E02A-400F-11DB-9590-000C2911D1B8", OperatingSystem::VmWare);
+    (VMWARE_VMFS, "AA31E02A-400F-11DB-9590-000C2911D1B8", OperatingSystem::VmWare),
     /// VMware Reserved
-    (VMWARE_RESERVED, "9198EFFC-31C0-11DB-8F78-000C2911D1B8", OperatingSystem::VmWare);
+    (VMWARE_RESERVED, "9198EFFC-31C0-11DB-8F78-000C2911D1B8", OperatingSystem::VmWare),
     /// Android Bootloader
-    (ANDROID_BOOTLOADER, "2568845D-2332-4675-BC39-8FA5A4748D15", OperatingSystem::Android);
+    (ANDROID_BOOTLOADER, "2568845D-2332-4675-BC39-8FA5A4748D15", OperatingSystem::Android),
     /// Android Bootloader2
-    (ANDROID_BOOTLOADER2, "114EAFFE-1552-4022-B26E-9B053604CF84", OperatingSystem::Android);
+    (ANDROID_BOOTLOADER2, "114EAFFE-1552-4022-B26E-9B053604CF84", OperatingSystem::Android),
     /// Android Boot
-    (ANDROID_BOOT, "49A4D17F-93A3-45C1-A0DE-F50B2EBE2599", OperatingSystem::Android);
+    (ANDROID_BOOT, "49A4D17F-93A3-45C1-A0DE-F50B2EBE2599", OperatingSystem::Android),
     /// Android Recovery
-    (ANDROID_RECOVERY, "4177C722-9E92-4AAB-8644-43502BFD5506", OperatingSystem::Android);
+    (ANDROID_RECOVERY, "4177C722-9E92-4AAB-8644-43502BFD5506", OperatingSystem::Android),
     /// Android Misc
-    (ANDROID_MISC, "EF32A33B-A409-486C-9141-9FFB711F6266", OperatingSystem::Android);
+    (ANDROID_MISC, "EF32A33B-A409-486C-9141-9FFB711F6266", OperatingSystem::Android),
     /// Android Metadata
-    (ANDROID_META, "20AC26BE-20B7-11E3-84C5-6CFDB94711E9", OperatingSystem::Android);
+    (ANDROID_META, "20AC26BE-20B7-11E3-84C5-6CFDB94711E9", OperatingSystem::Android),
     /// Android System
-    (ANDROID_SYSTEM, "38F428E6-D326-425D-9140-6E0EA133647C", OperatingSystem::Android);
+    (ANDROID_SYSTEM, "38F428E6-D326-425D-9140-6E0EA133647C", OperatingSystem::Android),
     /// Android Cache
-    (ANDROID_CACHE, "A893EF21-E428-470A-9E55-0668FD91A2D9", OperatingSystem::Android);
+    (ANDROID_CACHE, "A893EF21-E428-470A-9E55-0668FD91A2D9", OperatingSystem::Android),
     /// Android Data
-    (ANDROID_DATA, "DC76DDA9-5AC1-491C-AF42-A82591580C0D", OperatingSystem::Android);
+    (ANDROID_DATA, "DC76DDA9-5AC1-491C-AF42-A82591580C0D", OperatingSystem::Android),
     /// Android Persistent
-    (ANDROID_PERSISTENT, "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1", OperatingSystem::Android);
+    (ANDROID_PERSISTENT, "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1", OperatingSystem::Android),
     /// Android Factory
-    (ANDROID_FACTORY, "8F68CC74-C5E5-48DA-BE91-A0C8C15E9C80", OperatingSystem::Android);
+    (ANDROID_FACTORY, "8F68CC74-C5E5-48DA-BE91-A0C8C15E9C80", OperatingSystem::Android),
     /// Android Fastboot/Tertiary
-    (ANDROID_FASTBOOT, "767941D0-2085-11E3-AD3B-6CFDB94711E9", OperatingSystem::Android);
+    (ANDROID_FASTBOOT, "767941D0-2085-11E3-AD3B-6CFDB94711E9", OperatingSystem::Android),
     /// Android OEM
-    (ANDROID_OEM, "AC6D7924-EB71-4DF8-B48D-E267B27148FF", OperatingSystem::Android);
+    (ANDROID_OEM, "AC6D7924-EB71-4DF8-B48D-E267B27148FF", OperatingSystem::Android),
     /// ONIE Boot
-    (ONIE_BOOT, "7412F7D5-A156-4B13-81DC-867174929325", OperatingSystem::Onie);
+    (ONIE_BOOT, "7412F7D5-A156-4B13-81DC-867174929325", OperatingSystem::Onie),
     /// ONIE Config
-    (ONIE_CONFIG, "D4E6E2CD-4469-46F3-B5CB-1BFF57AFC149", OperatingSystem::Onie);
+    (ONIE_CONFIG, "D4E6E2CD-4469-46F3-B5CB-1BFF57AFC149", OperatingSystem::Onie),
     /// PowerPC PReP Boot
-    (PPC_BOOT, "9E1A2D38-C612-4316-AA26-8B49521E5A8B", OperatingSystem::PowerPc);
+    (PPC_BOOT, "9E1A2D38-C612-4316-AA26-8B49521E5A8B", OperatingSystem::PowerPc),
     /// FreeDesktop Shared Boot Loader Configuration
-    (FREEDESK_BOOT, "BC13C2FF-59E6-4262-A352-B275FD6F7172", OperatingSystem::FreeDesktop);
+    (FREEDESK_BOOT, "BC13C2FF-59E6-4262-A352-B275FD6F7172", OperatingSystem::FreeDesktop),
     /// Atari Basic Data Partition (GEM, BGM, F32)
-    (ATARI_DATA, "734E5AFE-F61A-11E6-BC64-92361F002671", OperatingSystem::Atari);
+    (ATARI_DATA, "734E5AFE-F61A-11E6-BC64-92361F002671", OperatingSystem::Atari),
 }

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -133,16 +133,6 @@ impl Type {
     }
 }
 
-// partition_types! {
-//     /// unused
-//     (UNUSED, "00000000-0000-0000-0000-000000000000", OperatingSystem::None),
-//     /// MBR Partition Scheme
-//     (MBR, "024DEE41-33E7-11D3-9D69-0008C781F39F", OperatingSystem::None),
-//     /// EFI System Partition
-//     (EFI, "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", OperatingSystem::None),
-//     /// BIOS Boot Partition
-//     (BIOS, "21686148-6449-6E6F-744E-656564454649", OperatingSystem::None),
-// }
 
 partition_types! {
     /// unused
@@ -249,8 +239,8 @@ partition_types! {
     (SOLARIS_SWAP, "6A87C46F-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris Backup Partition
     (SOLARIS_BACKUP, "6A8B642B-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
-    /// /Solaris usr Partition
-    (SOLARIS_USR, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
+// /// /Solaris usr Partition
+// (SOLARIS_USR, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris /var Partition
     (SOLARIS_VAR, "6A8EF2E9-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris),
     /// Solaris /home Partition

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -109,7 +109,7 @@ macro_rules! partition_types {
                     $(
                         $guid => Ok(Type { guid: $guid, os: $os }),
                     )+
-                    _ => Err("Invalid.".to_string()),
+                    _ => Err("Invalid or unknown Partition Type GUID.".to_string()),
                 }
             }
         }

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -1,465 +1,468 @@
-use lazy_static::*;
-use std::collections::HashMap;
+//! Parition type constants
+use std::str::FromStr;
+use log::debug;
 
-lazy_static! {
-    pub static ref PART_HASHMAP: HashMap<String, (&'static str, &'static str)> = {
-        let mut m = HashMap::new();
-        m.insert(
-            "00000000-0000-0000-0000-000000000000".into(),
-            ("None", "Unused"),
-        );
-        m.insert(
-            "024DEE41-33E7-11D3-9D69-0008C781F39F".into(),
-            ("None", "MBR Partition Scheme"),
-        );
-        m.insert(
-            "C12A7328-F81F-11D2-BA4B-00A0C93EC93B".into(),
-            ("None", "EFI System Partition"),
-        );
-        m.insert(
-            "21686148-6449-6E6F-744E-656564454649".into(),
-            ("None", "BIOS Boot Partition"),
-        );
-        m.insert(
-            "D3BFE2DE-3DAF-11DF-BA40-E3A556D89593".into(),
-            ("None", "Intel Fast Flash (iFFS) Partition"),
-        );
-        m.insert(
-            "F4019732-066E-4E12-8273-346C5641494F".into(),
-            ("None", "Sony Boot Partition"),
-        );
-        m.insert(
-            "BFBFAFE7-A34F-448A-9A5B-6213EB736C22".into(),
-            ("None", "Lenovo Boot Partition"),
-        );
-        m.insert(
-            "E3C9E316-0B5C-4DB8-817D-F92DF00215AE".into(),
-            ("Windows", "Microsoft Reserved Partition"),
-        );
-        m.insert(
-            "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7".into(),
-            ("Windows", "Basic Data Partition"),
-        );
-        m.insert(
-            "5808C8AA-7E8F-42E0-85D2-E1E90434CFB3".into(),
-            ("Windows", "Logical Disk Manager Metadata Partition"),
-        );
-        m.insert(
-            "AF9B60A0-1431-4F62-BC68-3311714A69AD".into(),
-            ("Windows", "Logical Disk Manager Data Partition"),
-        );
-        m.insert(
-            "DE94BBA4-06D1-4D40-A16A-BFD50179D6AC".into(),
-            ("Windows", "Windows Recovery Environment"),
-        );
-        m.insert(
-            "37AFFC90-EF7D-4E96-91C3-2D7AE055B174".into(),
-            ("Windows", "IBM General Parallel File System Partition"),
-        );
-        m.insert(
-            "E75CAF8F-F680-4CEE-AFA3-B001E56EFC2D".into(),
-            ("Windows", "Storage Spaces Partition"),
-        );
-        m.insert(
-            "75894C1E-3AEB-11D3-B7C1-7B03A0000000".into(),
-            ("HP-UX", "Data Partition"),
-        );
-        m.insert(
-            "E2A1E728-32E3-11D6-A682-7B03A0000000".into(),
-            ("HP-UX", "Service Partition"),
-        );
-        m.insert(
-            "0FC63DAF-8483-4772-8E79-3D69D8477DE4".into(),
-            ("Linux", "Linux Filesystem Data"),
-        );
-        m.insert(
-            "A19D880F-05FC-4D3B-A006-743F0F84911E".into(),
-            ("Linux", "RAID Partition"),
-        );
-        m.insert(
-            "44479540-F297-41B2-9AF7-D131D5F0458A".into(),
-            ("Linux", "Root Partition (x86)"),
-        );
-        m.insert(
-            "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709".into(),
-            ("Linux", "Root Partition (x86-64)"),
-        );
-        m.insert(
-            "69DAD710-2CE4-4E3C-B16C-21A1D49ABED3".into(),
-            ("Linux", "Root Partition (32-bit ARM)"),
-        );
-        m.insert(
-            "B921B045-1DF0-41C3-AF44-4C6F280D3FAE".into(),
-            ("Linux", "Root Partition (64-bit ARM/AArch64)"),
-        );
-        m.insert(
-            "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F".into(),
-            ("Linux", "Swap Partition"),
-        );
-        m.insert(
-            "E6D6D379-F507-44C2-A23C-238F2A3DF928".into(),
-            ("Linux", "Logical Volume Manager Partition"),
-        );
-        m.insert(
-            "933AC7E1-2EB4-4F13-B844-0E14E2AEF915".into(),
-            ("Linux", "/home Partition"),
-        );
-        m.insert(
-            "3B8F8425-20E0-4F3B-907F-1A25A76F98E8".into(),
-            ("Linux", "/srv (Server Data) Partition"),
-        );
-        m.insert(
-            "7FFEC5C9-2D00-49B7-8941-3EA10A5586B7".into(),
-            ("Linux", "Plain dm-crypt Partition"),
-        );
-        m.insert(
-            "CA7D7CCB-63ED-4C53-861C-1742536059CC".into(),
-            ("Linux", "LUKS Partition"),
-        );
-        m.insert(
-            "8DA63339-0007-60C0-C436-083AC8230908".into(),
-            ("Linux", "Reserved"),
-        );
-        m.insert(
-            "83BD6B9D-7F41-11DC-BE0B-001560B84F0F".into(),
-            ("FreeBSD", "Boot Partition"),
-        );
-        m.insert(
-            "516E7CB4-6ECF-11D6-8FF8-00022D09712B".into(),
-            ("FreeBSD", "Data Partition"),
-        );
-        m.insert(
-            "516E7CB5-6ECF-11D6-8FF8-00022D09712B".into(),
-            ("FreeBSD", "Swap Partition"),
-        );
-        m.insert(
-            "516E7CB6-6ECF-11D6-8FF8-00022D09712B".into(),
-            ("FreeBSD", "Unix File System (UFS) Partition"),
-        );
-        m.insert(
-            "516E7CB8-6ECF-11D6-8FF8-00022D09712B".into(),
-            ("FreeBSD", "Vinium Volume Manager Partition"),
-        );
-        m.insert(
-            "516E7CBA-6ECF-11D6-8FF8-00022D09712B".into(),
-            ("FreeBSD", "ZFS Partition"),
-        );
-        m.insert(
-            "48465300-0000-11AA-AA11-00306543ECAC".into(),
-            (
-                "macOS Darwin",
-                "Hierarchical File System Plus (HFS+) Partition",
-            ),
-        );
-        m.insert(
-            "55465300-0000-11AA-AA11-00306543ECAC".into(),
-            ("macOS Darwin", "Apple UFS"),
-        );
-        m.insert(
-            "6A898CC3-1DD2-11B2-99A6-080020736631".into(),
-            ("macOS Darwin", "ZFS"),
-        );
-        m.insert(
-            "52414944-0000-11AA-AA11-00306543ECAC".into(),
-            ("macOS Darwin", "Apple RAID Partition"),
-        );
-        m.insert(
-            "52414944-5F4F-11AA-AA11-00306543ECAC".into(),
-            ("macOS Darwin", "APple RAID Partition, offline"),
-        );
-        m.insert(
-            "426F6F74-0000-11AA-AA11-00306543ECAC".into(),
-            ("macOS Darwin", "Apple Boot Partition (Recovery HD)"),
-        );
-        m.insert(
-            "4C616265-6C00-11AA-AA11-00306543ECAC".into(),
-            ("macOS Darwin", "Apple Label"),
-        );
-        m.insert(
-            "5265636F-7665-11AA-AA11-00306543ECAC".into(),
-            ("macOS Darwin", "Apple TV Recovery Partition"),
-        );
-        m.insert(
-            "53746F72-6167-11AA-AA11-00306543ECAC".into(),
-            ("macOS Darwin", "Apple Core Storage Partition"),
-        );
-        m.insert(
-            "B6FA30DA-92D2-4A9A-96F1-871EC6486200".into(),
-            ("macOS Darwin", "SoftRAID_Status"),
-        );
-        m.insert(
-            "2E313465-19B9-463F-8126-8A7993773801".into(),
-            ("macOS Darwin", "SoftRAID_Scratch"),
-        );
-        m.insert(
-            "FA709C7E-65B1-4593-BFD5-E71D61DE9B02".into(),
-            ("macOS Darwin", "SoftRAID_Volume"),
-        );
-        m.insert(
-            "BBBA6DF5-F46F-4A89-8F59-8765B2727503".into(),
-            ("macOS Darwin", "SOftRAID_Cache"),
-        );
-        m.insert(
-            "6A82CB45-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Boot Partition"),
-        );
-        m.insert(
-            "6A85CF4D-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Root Partition"),
-        );
-        m.insert(
-            "6A87C46F-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Swap Partition"),
-        );
-        m.insert(
-            "6A8B642B-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Backup Partition"),
-        );
-        m.insert(
-            "6A898CC3-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "/usr Partition"),
-        );
-        m.insert(
-            "6A8EF2E9-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "/var Partition"),
-        );
-        m.insert(
-            "6A90BA39-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "/home Partition"),
-        );
-        m.insert(
-            "6A9283A5-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Alternate Sector"),
-        );
-        m.insert(
-            "6A945A3B-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Reserved"),
-        );
-        m.insert(
-            "6A9630D1-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Reserved"),
-        );
-        m.insert(
-            "6A980767-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Reserved"),
-        );
-        m.insert(
-            "6A96237F-1DD2-11B2-99A6-080020736631".into(),
-            (" Solaris Illumos", "Reserved"),
-        );
-        m.insert(
-            "6A8D2AC7-1DD2-11B2-99A6-080020736631".into(),
-            ("Solaris Illumos", "Reserved"),
-        );
-        m.insert(
-            "49F48D32-B10E-11DC-B99B-0019D1879648".into(),
-            ("NetBSD", "Swap Partition"),
-        );
-        m.insert(
-            "49F48D5A-B10E-11DC-B99B-0019D1879648".into(),
-            ("NetBSD", "FFS Partition"),
-        );
-        m.insert(
-            "49F48D82-B10E-11DC-B99B-0019D1879648".into(),
-            ("NetBSD", "LFS Partition"),
-        );
-        m.insert(
-            "49F48DAA-B10E-11DC-B99B-0019D1879648".into(),
-            ("NetBSD", "RAID Partition"),
-        );
-        m.insert(
-            "2DB519C4-B10F-11DC-B99B-0019D1879648".into(),
-            ("NetBSD", "Concatenated Partition"),
-        );
-        m.insert(
-            "2DB519EC-B10F-11DC-B99B-0019D1879648".into(),
-            ("NetBSD", "Encrypted Partition"),
-        );
-        m.insert(
-            "FE3A2A5D-4F32-41A7-B725-ACCC3285A309".into(),
-            ("ChromeOS", "ChromeOS Kernel"),
-        );
-        m.insert(
-            "3CB8E202-3B7E-47DD-8A3C-7FF2A13CFCEC".into(),
-            ("ChromeOS", "ChromeOS rootfs"),
-        );
-        m.insert(
-            "2E0A753D-9E48-43B0-8337-B15192CB1B5E".into(),
-            ("ChromeOS", "ChromeOS Future Use"),
-        );
-        m.insert(
-            "5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6".into(),
-            ("ContainerLinux by CoreOS", "/usr partition (coreos-usr)"),
-        );
-        m.insert(
-            "3884DD41-8582-4404-B9A8-E9B84F2DF50E".into(),
-            (
-                "ContainerLinux by CoreOS",
-                "Resizable rootfs (coreos-resize)",
-            ),
-        );
-        m.insert(
-            "C95DC21A-DF0E-4340-8D7B-26CBFA9A03E0".into(),
-            (
-                "ContainerLinux by CoreOS",
-                "OEM customizations (coreos-reserved)",
-            ),
-        );
-        m.insert(
-            "BE9067B9-EA49-4F15-B4F6-F36F8C9E1818".into(),
-            (
-                "ContainerLinux by CoreOS",
-                "Root filesystem on RAID (coreos-root-raid)",
-            ),
-        );
-        m.insert(
-            "42465331-3BA3-10F1-802A-4861696B7521".into(),
-            ("Haiku", "Haiku BFS"),
-        );
-        m.insert(
-            "85D5E45E-237C-11E1-B4B3-E89A8F7FC3A7".into(),
-            ("MidnightBSD", "Boot Partition"),
-        );
-        m.insert(
-            "85D5E45A-237C-11E1-B4B3-E89A8F7FC3A7".into(),
-            ("MidnightBSD", "Data Partition"),
-        );
-        m.insert(
-            "85D5E45B-237C-11E1-B4B3-E89A8F7FC3A7".into(),
-            ("MidnightBSD", "Swap Partition"),
-        );
-        m.insert(
-            "0394EF8B-237E-11E1-B4B3-E89A8F7FC3A7".into(),
-            ("MidnightBSD", "Unix File System (UFS) Partition"),
-        );
-        m.insert(
-            "85D5E45C-237C-11E1-B4B3-E89A8F7FC3A7".into(),
-            ("MidnightBSD", "Vinium Volume Manager Partition"),
-        );
-        m.insert(
-            "85D5E45D-237C-11E1-B4B3-E89A8F7FC3A7".into(),
-            ("MidnightBSD", "ZFS Partition"),
-        );
-        m.insert(
-            "45B0969E-9B03-4F30-B4C6-B4B80CEFF106".into(),
-            ("Ceph", "Ceph Journal"),
-        );
-        m.insert(
-            "45B0969E-9B03-4F30-B4C6-5EC00CEFF106".into(),
-            ("Ceph", "Ceph dm-crypt Encryted Journal"),
-        );
-        m.insert(
-            "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D".into(),
-            ("Ceph", "Ceph OSD"),
-        );
-        m.insert(
-            "4FBD7E29-9D25-41B8-AFD0-5EC00CEFF05D".into(),
-            ("Ceph", "Ceph dm-crypt OSD"),
-        );
-        m.insert(
-            "89C57F98-2FE5-4DC0-89C1-F3AD0CEFF2BE".into(),
-            ("Ceph", "Ceph Disk In Creation"),
-        );
-        m.insert(
-            "89C57F98-2FE5-4DC0-89C1-5EC00CEFF2BE".into(),
-            ("Ceph", "Ceph dm-crypt Disk In Creation"),
-        );
-        m.insert(
-            "824CC7A0-36A8-11E3-890A-952519AD3F61".into(),
-            ("OpenBSD", "Data Partition"),
-        );
-        m.insert(
-            "CEF5A9AD-73BC-4601-89F3-CDEEEEE321A1".into(),
-            ("QNX", "Power-safe (QNX6) File System"),
-        );
-        m.insert(
-            "C91818F9-8025-47AF-89D2-F030D7000C2C".into(),
-            ("Plan 9", "Plan 9 Partition"),
-        );
-        m.insert(
-            "9D275380-40AD-11DB-BF97-000C2911D1B8".into(),
-            ("VMware ESX", "vmkcore (coredump partition)"),
-        );
-        m.insert(
-            "AA31E02A-400F-11DB-9590-000C2911D1B8".into(),
-            ("VMware ESX", "VMFS Filesystem Partition"),
-        );
-        m.insert(
-            "9198EFFC-31C0-11DB-8F78-000C2911D1B8".into(),
-            ("VMware ESX", "VMware Reserved"),
-        );
-        m.insert(
-            "2568845D-2332-4675-BC39-8FA5A4748D15".into(),
-            ("Android-IA", "Bootloader"),
-        );
-        m.insert(
-            "114EAFFE-1552-4022-B26E-9B053604CF84".into(),
-            ("Android-IA", "Bootloader2"),
-        );
-        m.insert(
-            "49A4D17F-93A3-45C1-A0DE-F50B2EBE2599".into(),
-            ("Android-IA", "Boot"),
-        );
-        m.insert(
-            "4177C722-9E92-4AAB-8644-43502BFD5506".into(),
-            ("Android-IA", "Recovery"),
-        );
-        m.insert(
-            "EF32A33B-A409-486C-9141-9FFB711F6266".into(),
-            ("Android-IA", "Misc"),
-        );
-        m.insert(
-            "20AC26BE-20B7-11E3-84C5-6CFDB94711E9".into(),
-            ("Android-IA", "Metadata"),
-        );
-        m.insert(
-            "38F428E6-D326-425D-9140-6E0EA133647C".into(),
-            ("Android-IA", "System"),
-        );
-        m.insert(
-            "A893EF21-E428-470A-9E55-0668FD91A2D9".into(),
-            ("Android-IA", "Cache"),
-        );
-        m.insert(
-            "DC76DDA9-5AC1-491C-AF42-A82591580C0D".into(),
-            ("Android-IA", "Data"),
-        );
-        m.insert(
-            "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1".into(),
-            ("Android-IA", "Persistent"),
-        );
-        m.insert(
-            "8F68CC74-C5E5-48DA-BE91-A0C8C15E9C80".into(),
-            ("Android-IA", "Factory"),
-        );
-        m.insert(
-            "767941D0-2085-11E3-AD3B-6CFDB94711E9".into(),
-            ("Android-IA", "Fastboot/Tertiary"),
-        );
-        m.insert(
-            "AC6D7924-EB71-4DF8-B48D-E267B27148FF".into(),
-            ("Android-IA", "OEM"),
-        );
-        m.insert(
-            "7412F7D5-A156-4B13-81DC-867174929325".into(),
-            ("ONIE", "Boot"),
-        );
-        m.insert(
-            "D4E6E2CD-4469-46F3-B5CB-1BFF57AFC149".into(),
-            ("ONIE", "Config"),
-        );
-        m.insert(
-            "9E1A2D38-C612-4316-AA26-8B49521E5A8B".into(),
-            ("PowerPC", "PReP Boot"),
-        );
-        m.insert(
-            "BC13C2FF-59E6-4262-A352-B275FD6F7172".into(),
-            ("Freedesktop", "Shared Boot Loader Configuration"),
-        );
-        m.insert(
-            "734E5AFE-F61A-11E6-BC64-92361F002671".into(),
-            ("Atari TOS", "Basic Data Partition (GEM, BGM, F32)"),
-        );
-        m
-    };
+/// The type
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Type {
+    /// Type-GUID for a GPT partition.
+    pub guid: &'static str,
+    /// well-known OS label for this type-GUID.
+    pub os: OperatingSystem,
+}
+
+/// Operating System
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum OperatingSystem {
+    /// No OS
+    None,
+    /// Android OS
+    Android,
+    /// Atari
+    Atari,
+    /// Ceph
+    Ceph,
+    /// ChromeOS
+    Chrome,
+    /// CoreOs
+    CoreOs,
+    /// Custom
+    Custom(String),
+    /// FreeBsd
+    FreeBsd,
+    /// FreeDesktop
+    FreeDesktop,
+    /// Haiku
+    Haiku,
+    /// Hp Unix
+    HpUnix,
+    /// Linux
+    Linux,
+    /// MidnightBsd
+    MidnightBsd,
+    /// MacOs
+    MacOs,
+    /// NetBsd
+    NetBsd,
+    /// Onie
+    Onie,
+    /// OpenBSD
+    OpenBsd,
+    /// Plan9
+    Plan9,
+    /// PowerPC
+    PowerPc,
+    /// Solaris
+    Solaris,
+    /// VmWare
+    VmWare,
+    /// Windows
+    Windows,
+    /// QNX
+    QNX,
+}
+
+impl FromStr for OperatingSystem {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "unused" => Ok(OperatingSystem::None),
+            "android" => Ok(OperatingSystem::Android),
+            "atari" => Ok(OperatingSystem::Atari),
+            "Ceph" => Ok(OperatingSystem::Ceph),
+            "Chrome" => Ok(OperatingSystem::Chrome),
+            "FreeBsd" => Ok(OperatingSystem::FreeBsd),
+            "FreeDesktop" => Ok(OperatingSystem::FreeDesktop),
+            "Haiku" => Ok(OperatingSystem::Haiku),
+            "HP-UX" => Ok(OperatingSystem::HpUnix),
+            "Linux" => Ok(OperatingSystem::Linux),
+            "MacOS" => Ok(OperatingSystem::MacOs),
+            "MidnightBsd" => Ok(OperatingSystem::MidnightBsd),
+            "Onie" => Ok(OperatingSystem::Onie),
+            "PowerPc" => Ok(OperatingSystem::PowerPc),
+            "Solaris Illumos" => Ok(OperatingSystem::Solaris),
+            _ => Err(format!("Unknown operating system: {}", s)),
+        }
+    }
+}
+
+macro_rules! partition_types {
+    (
+        $(
+            $(#[$docs:meta])*
+            ($upcase:ident, $guid:expr, $os:expr);
+        )+
+    ) => {
+        $(
+            $(#[$docs])*
+            pub const $upcase: Type = Type {
+                guid: $guid,
+                os: $os,
+            };
+        )+
+    }
+}
+
+#[test]
+fn test_partition_fromstr() {
+    let p = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
+    let t = Type::from_str(p).unwrap();
+    println!("result: {:?}", t);
+    assert_eq!(t, LINUX_FS);
+}
+
+impl FromStr for Type {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        debug!("looking up partition type guid {}", s);
+        match s {
+            "00000000-0000-0000-0000-000000000000" => Ok(UNUSED),
+            "024DEE41-33E7-11D3-9D69-0008C781F39F" => Ok(MBR),
+            "C12A7328-F81F-11D2-BA4B-00A0C93EC93B" => Ok(EFI),
+            "21686148-6449-6E6F-744E-656564454649" => Ok(BIOS),
+            "D3BFE2DE-3DAF-11DF-BA40-E3A556D89593" => Ok(FLASH),
+            "F4019732-066E-4E12-8273-346C5641494F" => Ok(SONY_BOOT),
+            "BFBFAFE7-A34F-448A-9A5B-6213EB736C22" => Ok(LENOVO_BOOT),
+            "E3C9E316-0B5C-4DB8-817D-F92DF00215AE" => Ok(MICROSOFT_RESERVED),
+            "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7" => Ok(BASIC),
+            "5808C8AA-7E8F-42E0-85D2-E1E90434CFB3" => Ok(WINDOWS_METADATA),
+            "AF9B60A0-1431-4F62-BC68-3311714A69AD" => Ok(WINDOWS_DATA),
+            "DE94BBA4-06D1-4D40-A16A-BFD50179D6AC" => Ok(WINDOWS_RECOVERY),
+            "37AFFC90-EF7D-4E96-91C3-2D7AE055B174" => Ok(WINDOWS_PARALLEL),
+            "E75CAF8F-F680-4CEE-AFA3-B001E56EFC2D" => Ok(WINDOWS_STORAGESPACES),
+            "75894C1E-3AEB-11D3-B7C1-7B03A0000000" => Ok(HPUNIX_DATA),
+            "E2A1E728-32E3-11D6-A682-7B03A0000000" => Ok(HPUNIX_SERVICE),
+            "0FC63DAF-8483-4772-8E79-3D69D8477DE4" => Ok(LINUX_FS),
+            "A19D880F-05FC-4D3B-A006-743F0F84911E" => Ok(LINUX_RAID),
+            "44479540-F297-41B2-9AF7-D131D5F0458A" => Ok(LINUX_ROOT_X86),
+            "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709" => Ok(LINUX_ROOT_X64),
+            "69DAD710-2CE4-4E3C-B16C-21A1D49ABED3" => Ok(LINUX_ROOT_ARM_32),
+            "B921B045-1DF0-41C3-AF44-4C6F280D3FAE" => Ok(LINUX_ROOT_ARM_64),
+            "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F" => Ok(LINUX_SWAP),
+            "E6D6D379-F507-44C2-A23C-238F2A3DF928" => Ok(LINUX_LVM),
+            "933AC7E1-2EB4-4F13-B844-0E14E2AEF915" => Ok(LINUX_HOME),
+            "3B8F8425-20E0-4F3B-907F-1A25A76F98E8" => Ok(LINUX_SRV),
+            "7FFEC5C9-2D00-49B7-8941-3EA10A5586B7" => Ok(LINUX_DMCRYPT),
+            "CA7D7CCB-63ED-4C53-861C-1742536059CC" => Ok(LINUX_LUKS),
+            "8DA63339-0007-60C0-C436-083AC8230908" => Ok(LINUX_RESERVED),
+            "516E7CB4-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_DATA),
+            "83BD6B9D-7F41-11DC-BE0B-001560B84F0F" => Ok(FREEBSD_BOOT),
+            "516E7CB5-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_SWAP),
+            "516E7CB6-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_UFS),
+            "516E7CB8-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_VINIUM),
+            "516E7CBA-6ECF-11D6-8FF8-00022D09712B" => Ok(FREEBSD_ZFS),
+            "48465300-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_HFSPLUS),
+            "55465300-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_UFS),
+            "6A898CC3-1DD2-11B2-99A6-080020736631" => Ok(MACOS_ZFS),
+            "52414944-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_RAID),
+            "52414944-5F4F-11AA-AA11-00306543ECAC" => Ok(MACOS_RAID_OFFLINE),
+            "426F6F74-0000-11AA-AA11-00306543ECAC" => Ok(MACOS_RECOVERY),
+            "4C616265-6C00-11AA-AA11-00306543ECAC" => Ok(MACOS_LABEL),
+            "5265636F-7665-11AA-AA11-00306543ECAC" => Ok(MACOS_TV_RECOVERY),
+            "53746F72-6167-11AA-AA11-00306543ECAC" => Ok(MACOS_CORE),
+            "B6FA30DA-92D2-4A9A-96F1-871EC6486200" => Ok(MACOS_SOFTRAID_STATUS),
+            "2E313465-19B9-463F-8126-8A7993773801" => Ok(MACOS_SOFTRAID_SCRATCH),
+            "FA709C7E-65B1-4593-BFD5-E71D61DE9B02" => Ok(MACOS_SOFTRAID_VOLUME),
+            "BBBA6DF5-F46F-4A89-8F59-8765B2727503" => Ok(MACOS_SOFTRAID_CACHE),
+            "6A82CB45-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_BOOT),
+            "6A85CF4D-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_ROOT),
+            "6A87C46F-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_SWAP),
+            "6A8B642B-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_BACKUP),
+            //"6A898CC3-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_USR),
+            "6A8EF2E9-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_VAR),
+            "6A90BA39-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_HOME),
+            "6A9283A5-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_ALT),
+            "6A945A3B-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED1),
+            "6A9630D1-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED2),
+            "6A980767-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED3),
+            "6A96237F-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED4),
+            "6A8D2AC7-1DD2-11B2-99A6-080020736631" => Ok(SOLARIS_RESERVED5),
+            "49F48D32-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_SWAP),
+            "49F48D5A-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_FFS),
+            "49F48D82-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_LFS),
+            "49F48DAA-B10E-11DC-B99B-0019D1879648" => Ok(NETBSD_RAID),
+            "2DB519C4-B10F-11DC-B99B-0019D1879648" => Ok(NETBSD_CONCAT),
+            "2DB519EC-B10F-11DC-B99B-0019D1879648" => Ok(NETBSD_ENCRYPTED),
+            "FE3A2A5D-4F32-41A7-B725-ACCC3285A309" => Ok(CHROME_KERNEL),
+            "3CB8E202-3B7E-47DD-8A3C-7FF2A13CFCEC" => Ok(CHROME_ROOTFS),
+            "2E0A753D-9E48-43B0-8337-B15192CB1B5E" => Ok(CHROME_FUTURE),
+            "5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6" => Ok(COREOS_USR),
+            "3884DD41-8582-4404-B9A8-E9B84F2DF50E" => Ok(COREOS_ROOTFS_RESIZE),
+            "C95DC21A-DF0E-4340-8D7B-26CBFA9A03E0" => Ok(COREOS_OEM),
+            "BE9067B9-EA49-4F15-B4F6-F36F8C9E1818" => Ok(COREOS_ROOT_RAID),
+            "42465331-3BA3-10F1-802A-4861696B7521" => Ok(HAIKU_BFS),
+            "85D5E45E-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_BOOT),
+            "85D5E45A-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_DATA),
+            "85D5E45B-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_SWAP),
+            "0394EF8B-237E-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_UFS),
+            "85D5E45C-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_VINIUM),
+            "85D5E45D-237C-11E1-B4B3-E89A8F7FC3A7" => Ok(MIDNIGHT_ZFS),
+            "45B0969E-9B03-4F30-B4C6-B4B80CEFF106" => Ok(CEPH_JOURNAL),
+            "45B0969E-9B03-4F30-B4C6-5EC00CEFF106" => Ok(CEPH_CRYPT_JOURNAL),
+            "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D" => Ok(CEPH_OSD),
+            "4FBD7E29-9D25-41B8-AFD0-5EC00CEFF05D" => Ok(CEPH_CRYPT),
+            "89C57F98-2FE5-4DC0-89C1-F3AD0CEFF2BE" => Ok(CEPH_DISK_CREATION),
+            "89C57F98-2FE5-4DC0-89C1-5EC00CEFF2BE" => Ok(CEPH_CRYPT_CREATION),
+            "824CC7A0-36A8-11E3-890A-952519AD3F61" => Ok(OPENBSD_DATA),
+            "CEF5A9AD-73BC-4601-89F3-CDEEEEE321A1" => Ok(QNX_FS),
+            "C91818F9-8025-47AF-89D2-F030D7000C2C" => Ok(PLAN9_PART),
+            "9D275380-40AD-11DB-BF97-000C2911D1B8" => Ok(VMWARE_COREDUMP),
+            "AA31E02A-400F-11DB-9590-000C2911D1B8" => Ok(VMWARE_VMFS),
+            "9198EFFC-31C0-11DB-8F78-000C2911D1B8" => Ok(VMWARE_RESERVED),
+            "2568845D-2332-4675-BC39-8FA5A4748D15" => Ok(ANDROID_BOOTLOADER),
+            "114EAFFE-1552-4022-B26E-9B053604CF84" => Ok(ANDROID_BOOTLOADER2),
+            "49A4D17F-93A3-45C1-A0DE-F50B2EBE2599" => Ok(ANDROID_BOOT),
+            "4177C722-9E92-4AAB-8644-43502BFD5506" => Ok(ANDROID_RECOVERY),
+            "EF32A33B-A409-486C-9141-9FFB711F6266" => Ok(ANDROID_MISC),
+            "20AC26BE-20B7-11E3-84C5-6CFDB94711E9" => Ok(ANDROID_META),
+            "38F428E6-D326-425D-9140-6E0EA133647C" => Ok(ANDROID_SYSTEM),
+            "A893EF21-E428-470A-9E55-0668FD91A2D9" => Ok(ANDROID_CACHE),
+            "DC76DDA9-5AC1-491C-AF42-A82591580C0D" => Ok(ANDROID_DATA),
+            "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1" => Ok(ANDROID_PERSISTENT),
+            "8F68CC74-C5E5-48DA-BE91-A0C8C15E9C80" => Ok(ANDROID_FACTORY),
+            "767941D0-2085-11E3-AD3B-6CFDB94711E9" => Ok(ANDROID_FASTBOOT),
+            "AC6D7924-EB71-4DF8-B48D-E267B27148FF" => Ok(ANDROID_OEM),
+            "7412F7D5-A156-4B13-81DC-867174929325" => Ok(ONIE_BOOT),
+            "D4E6E2CD-4469-46F3-B5CB-1BFF57AFC149" => Ok(ONIE_CONFIG),
+            "9E1A2D38-C612-4316-AA26-8B49521E5A8B" => Ok(PPC_BOOT),
+            "BC13C2FF-59E6-4262-A352-B275FD6F7172" => Ok(FREEDESK_BOOT),
+            "734E5AFE-F61A-11E6-BC64-92361F002671" => Ok(ATARI_DATA),
+            _ => Err("Unknown Partition Type".to_string()),
+        }
+    }
+}
+
+impl Type {
+    /// Lookup a partition type by uuid
+    pub fn from_uuid(u: &uuid::Uuid) -> Result<Self, String> {
+        let uuid_str = u.to_hyphenated().to_string().to_uppercase();
+        debug!("looking up partition type guid {}", uuid_str);
+        Type::from_str(&uuid_str)
+    }
+}
+
+partition_types! {
+    /// unused
+    (UNUSED, "00000000-0000-0000-0000-000000000000", OperatingSystem::None);
+    /// MBR Partition Scheme
+    (MBR, "024DEE41-33E7-11D3-9D69-0008C781F39F", OperatingSystem::None);
+    /// EFI System Partition
+    (EFI, "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", OperatingSystem::None);
+    /// BIOS Boot Partition
+    (BIOS, "21686148-6449-6E6F-744E-656564454649", OperatingSystem::None);
+    /// Intel Fast Flash (iFFS) Partition
+    (FLASH, "D3BFE2DE-3DAF-11DF-BA40-E3A556D89593",OperatingSystem::None);
+    /// Sony Boot Partition
+    (SONY_BOOT, "F4019732-066E-4E12-8273-346C5641494F", OperatingSystem::None);
+    /// Lenovo Boot Partition
+    (LENOVO_BOOT, "BFBFAFE7-A34F-448A-9A5B-6213EB736C22", OperatingSystem::None);
+    /// Microsoft Reserved Partition
+    (MICROSOFT_RESERVED, "E3C9E316-0B5C-4DB8-817D-F92DF00215AE", OperatingSystem::Windows);
+    /// Basic Data Partition
+    (BASIC, "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7", OperatingSystem::Windows);
+    /// Logical Disk Manager Metadata Partition
+    (WINDOWS_METADATA, "5808C8AA-7E8F-42E0-85D2-E1E90434CFB3", OperatingSystem::Windows);
+    /// Logical Disk Manager Data Partition
+    (WINDOWS_DATA, "AF9B60A0-1431-4F62-BC68-3311714A69AD", OperatingSystem::Windows);
+    /// Windows Recovery Environment
+    (WINDOWS_RECOVERY, "DE94BBA4-06D1-4D40-A16A-BFD50179D6AC", OperatingSystem::Windows);
+    /// IBM General Parallel File System Partition
+    (WINDOWS_PARALLEL, "37AFFC90-EF7D-4E96-91C3-2D7AE055B174", OperatingSystem::Windows);
+    /// Storage Spaces Partition
+    (WINDOWS_STORAGESPACES, "E75CAF8F-F680-4CEE-AFA3-B001E56EFC2D", OperatingSystem::Windows);
+    /// HP Unix Data Partition
+    (HPUNIX_DATA, "75894C1E-3AEB-11D3-B7C1-7B03A0000000", OperatingSystem::HpUnix);
+    /// HP Unix Service Partition
+    (HPUNIX_SERVICE, "E2A1E728-32E3-11D6-A682-7B03A0000000", OperatingSystem::HpUnix);
+    /// Linux Filesystem Data
+    (LINUX_FS, "0FC63DAF-8483-4772-8E79-3D69D8477DE4", OperatingSystem::Linux);
+    /// Linux RAID Partition
+    (LINUX_RAID, "A19D880F-05FC-4D3B-A006-743F0F84911E", OperatingSystem::Linux);
+    /// Linux Root Partition (x86)
+    (LINUX_ROOT_X86, "44479540-F297-41B2-9AF7-D131D5F0458A", OperatingSystem::Linux);
+    /// Linux Root Partition (x86-64)
+    (LINUX_ROOT_X64, "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709", OperatingSystem::Linux);
+    /// Linux Root Partition (32-bit ARM)
+    (LINUX_ROOT_ARM_32, "69DAD710-2CE4-4E3C-B16C-21A1D49ABED3", OperatingSystem::Linux);
+    /// Linux Root Partition (64-bit ARM/AArch64)
+    (LINUX_ROOT_ARM_64, "B921B045-1DF0-41C3-AF44-4C6F280D3FAE", OperatingSystem::Linux);
+    /// Linux Swap Partition
+    (LINUX_SWAP, "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F", OperatingSystem::Linux);
+    /// Linux Logical Volume Manager Partition
+    (LINUX_LVM, "E6D6D379-F507-44C2-A23C-238F2A3DF928", OperatingSystem::Linux);
+    /// Linux /home Partition
+    (LINUX_HOME, "933AC7E1-2EB4-4F13-B844-0E14E2AEF915", OperatingSystem::Linux);
+    /// Linux /srv (Server Data) Partition
+    (LINUX_SRV, "3B8F8425-20E0-4F3B-907F-1A25A76F98E8", OperatingSystem::Linux);
+    /// Linux Plain dm-crypt Partition
+    (LINUX_DMCRYPT, "7FFEC5C9-2D00-49B7-8941-3EA10A5586B7", OperatingSystem::Linux);
+    /// Linux LUKS Partition
+    (LINUX_LUKS, "CA7D7CCB-63ED-4C53-861C-1742536059CC", OperatingSystem::Linux);
+    /// Linux Reserved
+    (LINUX_RESERVED, "8DA63339-0007-60C0-C436-083AC8230908", OperatingSystem::Linux);
+    /// FreeBSD Data Partition
+    (FREEBSD_DATA, "516E7CB4-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    /// FreeBSD Boot Partition
+    (FREEBSD_BOOT, "83BD6B9D-7F41-11DC-BE0B-001560B84F0F", OperatingSystem::FreeBsd);
+    /// FreeBSD Swap Partition
+    (FREEBSD_SWAP, "516E7CB5-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    /// FreeBSD Unix File System (UFS) Partition
+    (FREEBSD_UFS, "516E7CB6-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    /// FreeBSD Vinium Volume Manager Partition
+    (FREEBSD_VINIUM, "516E7CB8-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    /// FreeBSD ZFS Partition
+    (FREEBSD_ZFS, "516E7CBA-6ECF-11D6-8FF8-00022D09712B", OperatingSystem::FreeBsd);
+    /// Apple Hierarchical File System Plus (HFS+) Partition
+    (MACOS_HFSPLUS, "48465300-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// Apple UFS
+    (MACOS_UFS, "55465300-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// Apple ZFS
+    (MACOS_ZFS, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::MacOs);
+    /// Apple RAID Partition
+    (MACOS_RAID, "52414944-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// APple RAID Partition, offline
+    (MACOS_RAID_OFFLINE, "52414944-5F4F-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// Apple Boot Partition (Recovery HD)
+    (MACOS_RECOVERY, "426F6F74-0000-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// Apple Label
+    (MACOS_LABEL, "4C616265-6C00-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// Apple TV Recovery Partition
+    (MACOS_TV_RECOVERY, "5265636F-7665-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// Apple Core Storage Partition
+    (MACOS_CORE, "53746F72-6167-11AA-AA11-00306543ECAC", OperatingSystem::MacOs);
+    /// Apple SoftRAID_Status
+    (MACOS_SOFTRAID_STATUS, "B6FA30DA-92D2-4A9A-96F1-871EC6486200", OperatingSystem::MacOs);
+    /// Apple SoftRAID_Scratch
+    (MACOS_SOFTRAID_SCRATCH, "2E313465-19B9-463F-8126-8A7993773801", OperatingSystem::MacOs);
+    /// Apple SoftRAID_Volume
+    (MACOS_SOFTRAID_VOLUME, "FA709C7E-65B1-4593-BFD5-E71D61DE9B02", OperatingSystem::MacOs);
+    /// Apple SOftRAID_Cache
+    (MACOS_SOFTRAID_CACHE, "BBBA6DF5-F46F-4A89-8F59-8765B2727503", OperatingSystem::MacOs);
+    /// Solaris Boot Partition
+    (SOLARIS_BOOT, "6A82CB45-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Root Partition
+    (SOLARIS_ROOT, "6A85CF4D-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Swap Partition
+    (SOLARIS_SWAP, "6A87C46F-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Backup Partition
+    (SOLARIS_BACKUP, "6A8B642B-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// /Solaris usr Partition
+    (SOLARIS_USR, "6A898CC3-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris /var Partition
+    (SOLARIS_VAR, "6A8EF2E9-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris /home Partition
+    (SOLARIS_HOME, "6A90BA39-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Alternate Sector
+    (SOLARIS_ALT, "6A9283A5-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Reserved
+    (SOLARIS_RESERVED1, "6A945A3B-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Reserved
+    (SOLARIS_RESERVED2, "6A9630D1-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Reserved
+    (SOLARIS_RESERVED3, "6A980767-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Reserved
+    (SOLARIS_RESERVED4, "6A96237F-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// Solaris Reserved
+    (SOLARIS_RESERVED5, "6A8D2AC7-1DD2-11B2-99A6-080020736631", OperatingSystem::Solaris);
+    /// NetBSD Swap Partition
+    (NETBSD_SWAP, "49F48D32-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    /// NetBSD FFS Partition
+    (NETBSD_FFS, "49F48D5A-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    /// NetBSD LFS Partition
+    (NETBSD_LFS, "49F48D82-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    /// NetBSD RAID Partition
+    (NETBSD_RAID, "49F48DAA-B10E-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    /// NetBSD Concatenated Partition
+    (NETBSD_CONCAT, "2DB519C4-B10F-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    /// NetBSD Encrypted Partition
+    (NETBSD_ENCRYPTED, "2DB519EC-B10F-11DC-B99B-0019D1879648", OperatingSystem::NetBsd);
+    /// ChromeOS Kernel
+    (CHROME_KERNEL, "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", OperatingSystem::Chrome);
+    /// ChromeOS rootfs
+    (CHROME_ROOTFS, "3CB8E202-3B7E-47DD-8A3C-7FF2A13CFCEC",OperatingSystem::Chrome);
+    /// ChromeOS Future Use
+    (CHROME_FUTURE, "2E0A753D-9E48-43B0-8337-B15192CB1B5E",OperatingSystem::Chrome);
+    /// CoreOS /usr partition (coreos-usr)
+    (COREOS_USR, "5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6", OperatingSystem::CoreOs);
+    /// CoreOS Resizable rootfs (coreos-resize)
+    (COREOS_ROOTFS_RESIZE, "3884DD41-8582-4404-B9A8-E9B84F2DF50E", OperatingSystem::CoreOs);
+    /// CoreOS OEM customizations (coreos-reserved)
+    (COREOS_OEM, "C95DC21A-DF0E-4340-8D7B-26CBFA9A03E0", OperatingSystem::CoreOs);
+    /// CoreOS Root filesystem on RAID (coreos-root-raid)
+    (COREOS_ROOT_RAID, "BE9067B9-EA49-4F15-B4F6-F36F8C9E1818", OperatingSystem::CoreOs);
+    /// Haiku BFS
+    (HAIKU_BFS, "42465331-3BA3-10F1-802A-4861696B7521", OperatingSystem::Haiku);
+    /// MidnightBSD Boot Partition
+    (MIDNIGHT_BOOT, "85D5E45E-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    /// MidnightBSD Data Partition
+    (MIDNIGHT_DATA, "85D5E45A-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    /// MidnightBSD Swap Partition
+    (MIDNIGHT_SWAP, "85D5E45B-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    /// MidnightBSD Unix File System (UFS) Partition
+    (MIDNIGHT_UFS, "0394EF8B-237E-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    /// MidnightBSD Vinium Volume Manager Partition
+    (MIDNIGHT_VINIUM, "85D5E45C-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    /// MidnightBSD ZFS Partition
+    (MIDNIGHT_ZFS, "85D5E45D-237C-11E1-B4B3-E89A8F7FC3A7", OperatingSystem::MidnightBsd);
+    /// Ceph Journal
+    (CEPH_JOURNAL, "45B0969E-9B03-4F30-B4C6-B4B80CEFF106", OperatingSystem::Ceph);
+    /// Ceph dm-crypt Encryted Journal
+    (CEPH_CRYPT_JOURNAL, "45B0969E-9B03-4F30-B4C6-5EC00CEFF106", OperatingSystem::Ceph);
+    /// Ceph OSD
+    (CEPH_OSD, "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D", OperatingSystem::Ceph);
+    /// Ceph dm-crypt OSD
+    (CEPH_CRYPT, "4FBD7E29-9D25-41B8-AFD0-5EC00CEFF05D", OperatingSystem::Ceph);
+    /// Ceph Disk In Creation
+    (CEPH_DISK_CREATION, "89C57F98-2FE5-4DC0-89C1-F3AD0CEFF2BE", OperatingSystem::Ceph);
+    /// Ceph dm-crypt Disk In Creation
+    (CEPH_CRYPT_CREATION, "89C57F98-2FE5-4DC0-89C1-5EC00CEFF2BE", OperatingSystem::Ceph);
+    /// OpenBSD Data Partition
+    (OPENBSD_DATA, "824CC7A0-36A8-11E3-890A-952519AD3F61", OperatingSystem::OpenBsd);
+    /// QNX Power-safe (QNX6) File System
+    (QNX_FS, "CEF5A9AD-73BC-4601-89F3-CDEEEEE321A1", OperatingSystem::QNX);
+    /// Plan 9 Partition
+    (PLAN9_PART, "C91818F9-8025-47AF-89D2-F030D7000C2C", OperatingSystem::Plan9);
+    /// VMWare vmkcore (coredump partition)
+    (VMWARE_COREDUMP, "9D275380-40AD-11DB-BF97-000C2911D1B8", OperatingSystem::VmWare);
+    /// VMWare VMFS Filesystem Partition
+    (VMWARE_VMFS, "AA31E02A-400F-11DB-9590-000C2911D1B8", OperatingSystem::VmWare);
+    /// VMware Reserved
+    (VMWARE_RESERVED, "9198EFFC-31C0-11DB-8F78-000C2911D1B8", OperatingSystem::VmWare);
+    /// Android Bootloader
+    (ANDROID_BOOTLOADER, "2568845D-2332-4675-BC39-8FA5A4748D15", OperatingSystem::Android);
+    /// Android Bootloader2
+    (ANDROID_BOOTLOADER2, "114EAFFE-1552-4022-B26E-9B053604CF84", OperatingSystem::Android);
+    /// Android Boot
+    (ANDROID_BOOT, "49A4D17F-93A3-45C1-A0DE-F50B2EBE2599", OperatingSystem::Android);
+    /// Android Recovery
+    (ANDROID_RECOVERY, "4177C722-9E92-4AAB-8644-43502BFD5506", OperatingSystem::Android);
+    /// Android Misc
+    (ANDROID_MISC, "EF32A33B-A409-486C-9141-9FFB711F6266", OperatingSystem::Android);
+    /// Android Metadata
+    (ANDROID_META, "20AC26BE-20B7-11E3-84C5-6CFDB94711E9", OperatingSystem::Android);
+    /// Android System
+    (ANDROID_SYSTEM, "38F428E6-D326-425D-9140-6E0EA133647C", OperatingSystem::Android);
+    /// Android Cache
+    (ANDROID_CACHE, "A893EF21-E428-470A-9E55-0668FD91A2D9", OperatingSystem::Android);
+    /// Android Data
+    (ANDROID_DATA, "DC76DDA9-5AC1-491C-AF42-A82591580C0D", OperatingSystem::Android);
+    /// Android Persistent
+    (ANDROID_PERSISTENT, "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1", OperatingSystem::Android);
+    /// Android Factory
+    (ANDROID_FACTORY, "8F68CC74-C5E5-48DA-BE91-A0C8C15E9C80", OperatingSystem::Android);
+    /// Android Fastboot/Tertiary
+    (ANDROID_FASTBOOT, "767941D0-2085-11E3-AD3B-6CFDB94711E9", OperatingSystem::Android);
+    /// Android OEM
+    (ANDROID_OEM, "AC6D7924-EB71-4DF8-B48D-E267B27148FF", OperatingSystem::Android);
+    /// ONIE Boot
+    (ONIE_BOOT, "7412F7D5-A156-4B13-81DC-867174929325", OperatingSystem::Onie);
+    /// ONIE Config
+    (ONIE_CONFIG, "D4E6E2CD-4469-46F3-B5CB-1BFF57AFC149", OperatingSystem::Onie);
+    /// PowerPC PReP Boot
+    (PPC_BOOT, "9E1A2D38-C612-4316-AA26-8B49521E5A8B", OperatingSystem::PowerPc);
+    /// FreeDesktop Shared Boot Loader Configuration
+    (FREEDESK_BOOT, "BC13C2FF-59E6-4262-A352-B275FD6F7172", OperatingSystem::FreeDesktop);
+    /// Atari Basic Data Partition (GEM, BGM, F32)
+    (ATARI_DATA, "734E5AFE-F61A-11E6-BC64-92361F002671", OperatingSystem::Atari);
 }

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -47,7 +47,6 @@ fn test_gptdisk_linux_01() {
 
     let p1 = &gdisk.partitions()[0];
     assert_eq!(p1.name, "primary");
-    assert_eq!(p1.part_type_guid.description, "Linux Filesystem Data");
     let p1_start = p1.bytes_start(*gdisk.logical_block_size()).unwrap();
     assert_eq!(p1_start, 0x22 * 512);
     let p1_len = p1.bytes_len(*gdisk.logical_block_size()).unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,12 +1,11 @@
-
-
 use simplelog;
 
 use uuid;
 
 use gpt::disk;
 use gpt::header::{read_header, write_header, Header};
-use gpt::partition::{read_partitions, Partition, PartitionType};
+use gpt::partition::{read_partitions, Partition};
+use gpt::partition_types::Type;
 use simplelog::{Config, SimpleLogger};
 use std::io::Write;
 use std::path::Path;
@@ -33,11 +32,7 @@ fn test_read_header() {
     };
 
     let expected_partition = Partition {
-        part_type_guid: PartitionType {
-            guid: uuid::Uuid::parse_str("0FC63DAF-8483-4772-8E79-3D69D8477DE4").unwrap(),
-            os: "Linux".to_string(),
-            description: "Linux Filesystem Data".to_string(),
-        },
+        part_type_guid: gpt::partition_types::LINUX_FS,
         part_guid: uuid::Uuid::from_str("6fcc8240-3985-4840-901f-a05e7fd9b69d").unwrap(),
         first_lba: 34,
         last_lba: 62,
@@ -80,11 +75,7 @@ fn test_write_header() {
     println!("header: {:#?}", h);
 
     let p = Partition {
-        part_type_guid: PartitionType {
-            guid: uuid::Uuid::parse_str("0FC63DAF-8483-4772-8E79-3D69D8477DE4").unwrap(),
-            os: "Linux".to_string(),
-            description: "Linux Filesystem Data".to_string(),
-        },
+        part_type_guid: Type::from_str("0FC63DAF-8483-4772-8E79-3D69D8477DE4").unwrap(),
         part_guid: uuid::Uuid::new_v4(),
         first_lba: 36,
         last_lba: 40,


### PR DESCRIPTION
Quyzi and I worked together on creating this PR that changes all the partition uuid's into constants.  This should make it easier for people using the library to identify which partition type they'd like.  

I tried to come up with a macro that would eliminate all the match statements but I couldn't quite get the compiler to accept it.  So for now all the uuid's are hard coded in the match statements though in the future I'd love for anyone to take a crack at eliminating that code.  

Inspiration for this PR came from the http library which takes a s similar approach to exposing library constants.  

Some possible improvements could be adding flexibility to the OperatingSystem and Type parsers to allow custom input like the http library does.  