### PR TITLE
Small tweaks to add partition

### DIFF
--- a/src/disk.rs
+++ b/src/disk.rs
@@ -1,7 +1,7 @@
 //! Disk-related types and helper functions.
 
 use super::{GptConfig, GptDisk};
-use std::{io, path};
+use std::{fmt, io, path};
 
 /// Default size of a logical sector (bytes).
 pub const DEFAULT_SECTOR_SIZE: LogicalBlockSize = LogicalBlockSize::Lb512;
@@ -20,6 +20,24 @@ impl Into<u64> for LogicalBlockSize {
         match self {
             LogicalBlockSize::Lb512 => 512,
             LogicalBlockSize::Lb4096 => 4096,
+        }
+    }
+}
+
+impl Into<usize> for LogicalBlockSize {
+    fn into(self) -> usize {
+        match self {
+            LogicalBlockSize::Lb512 => 512,
+            LogicalBlockSize::Lb4096 => 4096,
+        }
+    }
+}
+
+impl fmt::Display for LogicalBlockSize {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LogicalBlockSize::Lb512 => write!(f, "512"),
+            LogicalBlockSize::Lb4096 => write!(f, "1096"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ impl GptDisk {
     pub fn add_partition(
         &mut self,
         name: &str,
-        size: usize,
+        size: u64,
         part_type: partition_types::Type,
         flags: u64,
     ) -> io::Result<u32> {
@@ -175,7 +175,7 @@ impl GptDisk {
         // Find the lowest lba that is larger than size.
         let free_sections = self.find_free_sectors();
         for (starting_lba, length) in free_sections {
-            if length as usize >= size_lba {
+            if length >= size_lba {
                 // Found our free slice.
                 let partition_id = self.find_next_partition_id();
                 debug!(


### PR DESCRIPTION
I've changed the add_partition function slightly to return the
partition id.  Makes it easier to identify the partition that was
added later.  I also made the size specified be in bytes and noted
that in the docs.