### PR TITLE
Update byteorder from ~1.2 to ~1.3...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 bitflags = "~1.0"
-byteorder = { version = "~1.2", features = ["i128"] }
+byteorder = "~1.3"
 crc = "~1.8"
 log = "~0.4"
 uuid = { version = "~0.7", features = ["v4"] }


### PR DESCRIPTION
...remove now-deprecated `i128` feature.

Updates the requirements on [byteorder](https://github.com/BurntSushi/byteorder) to permit the latest version.
- [Release notes](https://github.com/BurntSushi/byteorder/releases)
- [Changelog](https://github.com/BurntSushi/byteorder/blob/master/CHANGELOG.md)
- [Commits](https://github.com/BurntSushi/byteorder/commits/1.3.0)

Signed-off-by: dependabot[bot] <support@dependabot.com>