### PR TITLE
Fix bug in partition id creation

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -2,6 +2,7 @@
 
 use crc::{crc32, Hasher32};
 use log::*;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
@@ -47,7 +48,7 @@ pub struct Header {
 impl Header {
     pub(crate) fn compute_new(
         primary: bool,
-        pp: &[partition::Partition],
+        pp: &BTreeMap<u32, partition::Partition>,
         guid: uuid::Uuid,
         backup_offset: u64,
     ) -> Result<Self> {
@@ -73,7 +74,7 @@ impl Header {
             last_usable: last,
             disk_guid: guid,
             part_start: 2,
-            num_parts: pp.iter().filter(|p| p.is_used()).count() as u32,
+            num_parts: pp.iter().filter(|p| p.1.is_used()).count() as u32,
             part_size: 128,
             crc32_parts: 0,
         };
@@ -385,7 +386,7 @@ pub fn write_header(
         }
     };
 
-    let hdr = Header::compute_new(true, &[], guid, bak)?;
+    let hdr = Header::compute_new(true, &BTreeMap::new(), guid, bak)?;
     debug!("new header: {:#?}", hdr);
     hdr.write_primary(&mut file, sector_size)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,20 +274,6 @@ impl GptDisk {
         &self.config.lb_size
     }
 
-    /*
-    /// Sort the partitions by their starting LBA.  Takes into
-    /// account unused partitions.
-    pub fn sort_partitions(&mut self) {
-        self.partitions
-            .sort_by(|a, b| match (a.is_used(), b.is_used()) {
-                (true, true) => a.first_lba.cmp(&b.first_lba),
-                (true, false) => Ordering::Less,
-                (false, true) => Ordering::Greater,
-                (false, false) => Ordering::Equal,
-            });
-    }
-    */
-
     /// Update disk UUID.
     ///
     /// If no UUID is specified, a new random one is generated.

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -1,5 +1,5 @@
 //! Parition type constants
-use log::debug;
+use log::trace;
 use std::str::FromStr;
 
 /// The type
@@ -99,7 +99,7 @@ impl Type {
     /// Lookup a partition type by uuid
     pub fn from_uuid(u: &uuid::Uuid) -> Result<Self, String> {
         let uuid_str = u.to_hyphenated().to_string().to_uppercase();
-        debug!("looking up partition type guid {}", uuid_str);
+        trace!("looking up partition type guid {}", uuid_str);
         Type::from_str(&uuid_str)
     }
 }

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -45,7 +45,7 @@ fn test_gptdisk_linux_01() {
     assert_eq!(h2.current_lba, 95);
     assert_eq!(h2.backup_lba, 1);
 
-    let p1 = &gdisk.partitions()[0];
+    let p1 = &gdisk.partitions().get(&1_u32).unwrap();
     assert_eq!(p1.name, "primary");
     let p1_start = p1.bytes_start(*gdisk.logical_block_size()).unwrap();
     assert_eq!(p1_start, 0x22 * 512);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -38,7 +38,6 @@ fn test_read_header() {
         last_lba: 62,
         flags: 0,
         name: "primary".to_string(),
-        id: 0,
     };
 
     let diskpath = Path::new("tests/fixtures/gpt-linux-disk-01.img");
@@ -49,7 +48,7 @@ fn test_read_header() {
 
     let p = read_partitions(diskpath, &h, disk::DEFAULT_SECTOR_SIZE).unwrap();
     println!("Partitions: {:?}", p);
-    assert_eq!(p[0], expected_partition);
+    assert_eq!(*p.get(&1).unwrap(), expected_partition);
 }
 
 #[test]
@@ -81,8 +80,7 @@ fn test_write_header() {
         last_lba: 40,
         flags: 0,
         name: "gpt test".to_string(),
-        id: 0,
     };
-    p.write(tempdisk.path(), h.part_start, disk::DEFAULT_SECTOR_SIZE)
+    p.write(tempdisk.path(), 0, h.part_start, disk::DEFAULT_SECTOR_SIZE)
         .unwrap();
 }


### PR DESCRIPTION
The partition id returned from creating partitions was always wrong.  Partition id's start at one and not zero.  This patch fixes that.  It uses a BTreeMap to maintain sorted order of the partitions.