### PR TITLE
Fixed file_read_partitions so that it skips unused partition entries

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -276,21 +276,21 @@ pub(crate) fn file_read_header(file: &mut File, offset: u64) -> Result<Header> {
 
     let h = Header {
         signature: sigstr.to_string(),
-        revision: u32::from_ne_bytes(read_exact_buff!(rev, reader, 4)),
-        header_size_le: u32::from_ne_bytes(read_exact_buff!(hsle, reader, 4)),
-        crc32: u32::from_ne_bytes(read_exact_buff!(crc32, reader, 4)),
-        reserved: u32::from_ne_bytes(read_exact_buff!(reserv, reader, 4)),
-        current_lba: u64::from_ne_bytes(read_exact_buff!(clba, reader, 8)),
-        backup_lba: u64::from_ne_bytes(read_exact_buff!(blba, reader, 8)),
-        first_usable: u64::from_ne_bytes(read_exact_buff!(fusable, reader, 8)),
-        last_usable: u64::from_ne_bytes(read_exact_buff!(lusable, reader, 8)),
+        revision: u32::from_le_bytes(read_exact_buff!(rev, reader, 4)),
+        header_size_le: u32::from_le_bytes(read_exact_buff!(hsle, reader, 4)),
+        crc32: u32::from_le_bytes(read_exact_buff!(crc32, reader, 4)),
+        reserved: u32::from_le_bytes(read_exact_buff!(reserv, reader, 4)),
+        current_lba: u64::from_le_bytes(read_exact_buff!(clba, reader, 8)),
+        backup_lba: u64::from_le_bytes(read_exact_buff!(blba, reader, 8)),
+        first_usable: u64::from_le_bytes(read_exact_buff!(fusable, reader, 8)),
+        last_usable: u64::from_le_bytes(read_exact_buff!(lusable, reader, 8)),
         disk_guid: parse_uuid(&mut reader)?,
-        part_start: u64::from_ne_bytes(read_exact_buff!(pstart, reader, 8)),
+        part_start: u64::from_le_bytes(read_exact_buff!(pstart, reader, 8)),
         // Note: this will always return the total number of partition entries
         // in the array, not how many are actually used
-        num_parts: u32::from_ne_bytes(read_exact_buff!(nparts, reader, 4)),
-        part_size: u32::from_ne_bytes(read_exact_buff!(partsize, reader, 4)),
-        crc32_parts: u32::from_ne_bytes(read_exact_buff!(crc32parts, reader, 4)),
+        num_parts: u32::from_le_bytes(read_exact_buff!(nparts, reader, 4)),
+        part_size: u32::from_le_bytes(read_exact_buff!(partsize, reader, 4)),
+        crc32_parts: u32::from_le_bytes(read_exact_buff!(crc32parts, reader, 4)),
     };
     trace!("header: {:?}", &hdr[..]);
     trace!("header gpt: {}", h.disk_guid.to_hyphenated().to_string());

--- a/src/header.rs
+++ b/src/header.rs
@@ -276,23 +276,24 @@ pub(crate) fn file_read_header(file: &mut File, offset: u64) -> Result<Header> {
 
     let h = Header {
         signature: sigstr.to_string(),
-        revision: u32::from_le_bytes( read_exact_buff!(rev, reader, 4) ),
-        header_size_le: u32::from_le_bytes( read_exact_buff!(hsle, reader, 4) ),
-        crc32: u32::from_le_bytes( read_exact_buff!(crc32, reader, 4) ),
-        reserved: u32::from_le_bytes( read_exact_buff!(reserv, reader, 4) ),
-        current_lba: u64::from_le_bytes( read_exact_buff!(clba, reader, 8) ),
-        backup_lba: u64::from_le_bytes( read_exact_buff!(blba, reader, 8) ),
-        first_usable: u64::from_le_bytes( read_exact_buff!(fusable, reader, 8) ),
-        last_usable: u64::from_le_bytes( read_exact_buff!(lusable, reader, 8) ),
+        revision: u32::from_ne_bytes(read_exact_buff!(rev, reader, 4)),
+        header_size_le: u32::from_ne_bytes(read_exact_buff!(hsle, reader, 4)),
+        crc32: u32::from_ne_bytes(read_exact_buff!(crc32, reader, 4)),
+        reserved: u32::from_ne_bytes(read_exact_buff!(reserv, reader, 4)),
+        current_lba: u64::from_ne_bytes(read_exact_buff!(clba, reader, 8)),
+        backup_lba: u64::from_ne_bytes(read_exact_buff!(blba, reader, 8)),
+        first_usable: u64::from_ne_bytes(read_exact_buff!(fusable, reader, 8)),
+        last_usable: u64::from_ne_bytes(read_exact_buff!(lusable, reader, 8)),
         disk_guid: parse_uuid(&mut reader)?,
-        part_start: u64::from_le_bytes( read_exact_buff!(pstart, reader, 8) ),
-        num_parts: u32::from_le_bytes( read_exact_buff!(nparts, reader, 4) ),
-        part_size: u32::from_le_bytes( read_exact_buff!(partsize, reader, 4) ),
-        crc32_parts: u32::from_le_bytes( read_exact_buff!(crc32parts, reader, 4) ),
+        part_start: u64::from_ne_bytes(read_exact_buff!(pstart, reader, 8)),
+        // Note: this will always return the total number of partition entries
+        // in the array, not how many are actually used
+        num_parts: u32::from_ne_bytes(read_exact_buff!(nparts, reader, 4)),
+        part_size: u32::from_ne_bytes(read_exact_buff!(partsize, reader, 4)),
+        crc32_parts: u32::from_ne_bytes(read_exact_buff!(crc32parts, reader, 4)),
     };
     trace!("header: {:?}", &hdr[..]);
     trace!("header gpt: {}", h.disk_guid.to_hyphenated().to_string());
-
     let mut hdr_crc = hdr;
     for crc_byte in hdr_crc.iter_mut().skip(16).take(4) {
         *crc_byte = 0;
@@ -392,4 +393,3 @@ pub fn write_header(
 
     Ok(guid)
 }
-

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,15 +1,18 @@
+
 #[macro_use]
 pub(crate) mod crate_macros {
     /// Macro to read an exact buffer
     macro_rules! read_exact_buff {
-        ($bufid:ident, $rdr:expr, $buflen:expr) => {{
-            let mut $bufid = [0u8; $buflen];
-            let _ = $rdr.read_exact(&mut $bufid)?;
-            $bufid
-        }};
+        ($bufid:ident, $rdr:expr, $buflen:expr) => {
+            {
+                let mut $bufid = [0u8; $buflen];
+                let _ = $rdr.read_exact(&mut $bufid)?;
+                $bufid
+            }
+        }
     }
 
-    /// Macro to create const for partition types.
+    /// Macro to create const for partition types. 
     macro_rules! partition_types {
     (
         $(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,18 +1,15 @@
-
 #[macro_use]
 pub(crate) mod crate_macros {
     /// Macro to read an exact buffer
     macro_rules! read_exact_buff {
-        ($bufid:ident, $rdr:expr, $buflen:expr) => {
-            {
-                let mut $bufid = [0u8; $buflen];
-                let _ = $rdr.read_exact(&mut $bufid)?;
-                $bufid
-            }
-        }
+        ($bufid:ident, $rdr:expr, $buflen:expr) => {{
+            let mut $bufid = [0u8; $buflen];
+            let _ = $rdr.read_exact(&mut $bufid)?;
+            $bufid
+        }};
     }
 
-    /// Macro to create const for partition types. 
+    /// Macro to create const for partition types.
     macro_rules! partition_types {
     (
         $(

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -227,6 +227,8 @@ pub(crate) fn file_read_partitions(
     let mut parts: BTreeMap<u32, Partition> = BTreeMap::new();
 
     trace!("scanning {} partitions", header.num_parts);
+    debug!("Number of parts {:?}\n\n", header.num_parts);
+    let mut count = 0;
     for i in 0..header.num_parts {
         let mut bytes: [u8; 56] = [0; 56];
         let mut nameraw: [u8; 72] = [0; 72];
@@ -234,24 +236,32 @@ pub(crate) fn file_read_partitions(
         file.read_exact(&mut bytes)?;
         file.read_exact(&mut nameraw)?;
 
-        let mut reader = Cursor::new(&bytes[..]);
-        let type_guid = parse_uuid(&mut reader)?;
-        let part_guid = parse_uuid(&mut reader)?;
+        let test: [u8; 56] = [0; 56];
+        let test2: [u8; 72] = [0; 72];
+        // Note: unused partition entries are zeroed, so skip them
+        if bytes.eq(&test[0..]) && nameraw.eq(&test2[0..]) {
+            count += 1;
+        } else {
+            let mut reader = Cursor::new(&bytes[..]);
+            let type_guid = parse_uuid(&mut reader)?;
+            let part_guid = parse_uuid(&mut reader)?;
 
-        let partname = read_part_name(&mut Cursor::new(&nameraw[..]))?;
-        let p = Partition {
-            part_type_guid: Type::from_uuid(&type_guid).map_err(|e| {
-                Error::new(ErrorKind::Other, format!("Unknown Partition Type: {}", e))
-            })?,
-            part_guid,
-            first_lba: u64::from_le_bytes(read_exact_buff!(flba, reader, 8)),
-            last_lba: u64::from_le_bytes(read_exact_buff!(llba, reader, 8)),
-            flags: u64::from_le_bytes(read_exact_buff!(flagbuff, reader, 8)),
-            name: partname.to_string(),
-        };
+            let partname = read_part_name(&mut Cursor::new(&nameraw[..]))?;
+            let p = Partition {
+                part_type_guid: Type::from_uuid(&type_guid).map_err(|e| {
+                    Error::new(ErrorKind::Other, format!("Unknown Partition Type: {}", e))
+                })?,
+                part_guid,
+                first_lba: u64::from_le_bytes(read_exact_buff!(flba, reader, 8)),
+                last_lba: u64::from_le_bytes(read_exact_buff!(llba, reader, 8)),
+                flags: u64::from_le_bytes(read_exact_buff!(flagbuff, reader, 8)),
+                name: partname.to_string(),
+            };
 
-        parts.insert(i + 1, p);
+            parts.insert(i + 1, p);
+        }
     }
+    debug!("Num Zeroed partitions {:?}\n\n", count);
 
     debug!("checking partition table CRC");
     let _ = file.seek(SeekFrom::Start(pstart))?;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -227,7 +227,6 @@ pub(crate) fn file_read_partitions(
     let mut parts: BTreeMap<u32, Partition> = BTreeMap::new();
 
     trace!("scanning {} partitions", header.num_parts);
-    debug!("Number of parts {:?}\n\n", header.num_parts);
     let mut count = 0;
     for i in 0..header.num_parts {
         let mut bytes: [u8; 56] = [0; 56];

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -1,6 +1,5 @@
 use gpt;
 
-
 use gpt::disk;
 use std::path;
 use tempfile::NamedTempFile;
@@ -16,7 +15,8 @@ fn test_gptconfig_empty() {
     };
 
     let lb_size = disk::LogicalBlockSize::Lb4096;
-    let disk = cfg.initialized(false)
+    let disk = cfg
+        .initialized(false)
         .logical_block_size(lb_size)
         .open(tempdisk.path())
         .unwrap();
@@ -35,7 +35,7 @@ fn test_gptdisk_linux_01() {
     assert_eq!(*gdisk.logical_block_size(), lb_size);
     assert!(gdisk.primary_header().is_some());
     assert!(gdisk.backup_header().is_some());
-    assert_eq!(gdisk.partitions().len(), 128);
+    assert_eq!(gdisk.partitions().len(), 1);
 
     let h1 = gdisk.primary_header().unwrap();
     assert_eq!(h1.current_lba, 1);


### PR DESCRIPTION
The file_read_partitions function creates partitions for empty partition array entries.  This commit skips over the empty partition entries