### PR TITLE
Add the minimal necessary support required to read from Read + Seek devices

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -212,9 +212,9 @@ pub fn read_partitions(
     file_read_partitions(&mut file, header, lb_size)
 }
 
-/// Read a GPT partition table from an open `File` object.
-pub(crate) fn file_read_partitions(
-    file: &mut File,
+/// Read a GPT partition table from an open `Read` + `Seek` object.
+pub fn file_read_partitions<D: Read + Seek>(
+    file: &mut D,
     header: &Header,
     lb_size: disk::LogicalBlockSize,
 ) -> Result<BTreeMap<u32, Partition>> {


### PR DESCRIPTION
Changes some internal functions from taking a `File` to taking a `Read + Write` (or `Read + Write + Seek` when writing is required), and adds functions (`file_read_partitions` and `read_header_from_arbitrary_device`) to read the header and partitions from a `Read + Seek` device.