### PR TITLE
Take into account old disk header values when computing new header

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -86,7 +86,12 @@ impl Header {
             last_usable: last,
             disk_guid: guid,
             part_start: 2,
-            num_parts: pp.iter().filter(|p| p.1.is_used()).count() as u32,
+            // really this number should actually usually be 128, as it is the
+            // TOTAL number of entries in the partition table, NOT the number USED.
+            num_parts: match original_header {
+                Some(header) => header.num_parts,
+                None => pp.iter().filter(|p| p.1.is_used()).count() as u32,
+            },
             //though usually 128, it might be a different number
             part_size: match original_header {
                 Some(header) => header.part_size,

--- a/src/header.rs
+++ b/src/header.rs
@@ -66,28 +66,31 @@ impl Header {
         };
         let last = match original_header {
             Some(header) => header.last_usable,
-            None => backup_offset
-                .checked_sub(first)
-                .ok_or_else(|| Error::new(ErrorKind::Other, "header underflow - last usable"))?,
+            None => {
+                backup_offset
+                    .checked_sub(first)
+                    .ok_or_else(|| Error::new(ErrorKind::Other, "header underflow - last usable"))?
+                    + 1
+            } // its the alternate_lba (aka backup offset) - first_usable + 1, because LBA starts from 0
         };
+        // the partition entry LBA starts at 2 (usually) for primary headers and at the last_usable + 1 for backup headers
+        let part_start = if primary { 2 } else { last + 1 };
 
         let hdr = Header {
             signature: "EFI PART".to_string(),
             revision: 65536,
             header_size_le: 92,
-            crc32: match original_header {
-                Some(header) => header.crc32,
-                None => 0,
-            },
+            crc32: 0,
             reserved: 0,
             current_lba: cur,
             backup_lba: bak,
             first_usable: first,
             last_usable: last,
             disk_guid: guid,
-            part_start: 2,
+            part_start,
             // really this number should actually usually be 128, as it is the
             // TOTAL number of entries in the partition table, NOT the number USED.
+            // UEFI requires space for 128 minimum, but the number can be increased or reduced
             num_parts: match original_header {
                 Some(header) => header.num_parts,
                 None => pp.iter().filter(|p| p.1.is_used()).count() as u32,
@@ -97,10 +100,7 @@ impl Header {
                 Some(header) => header.part_size,
                 None => 128,
             },
-            crc32_parts: match original_header {
-                Some(header) => header.crc32_parts,
-                None => 0,
-            },
+            crc32_parts: 0,
         };
 
         Ok(hdr)
@@ -435,4 +435,290 @@ pub fn write_header(
     hdr.write_primary(&mut file, sector_size)?;
 
     Ok(guid)
+}
+
+#[test]
+// test compute new with fdisk'd image, without giving original header
+fn test_compute_new_fdisk_no_header() {
+    use tempfile;
+    let diskpath = Path::new("tests/fixtures/test.img");
+    let h = read_header(diskpath, disk::DEFAULT_SECTOR_SIZE).unwrap();
+    let cfg = crate::GptConfig::new().writable(false).initialized(true);
+    let disk = cfg.open(diskpath).unwrap();
+    println!("original Disk {:#?}", disk);
+    let partitions: BTreeMap<u32, partition::Partition> = BTreeMap::new();
+    let mut file = std::fs::OpenOptions::new()
+        .write(false)
+        .read(true)
+        .open(diskpath)
+        .unwrap();
+    let bak = find_backup_lba(&mut file, *disk.logical_block_size()).unwrap();
+    println!("Back offset {}", bak);
+    let mut tempdisk = tempfile::tempfile().expect("failed to create tempfile disk");
+    {
+        let data: [u8; 4096] = [0; 4096];
+        println!("Creating blank header file for testing");
+        for _ in 0..100 {
+            tempdisk.write_all(&data).unwrap();
+        }
+    };
+    let new_primary =
+        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+    println!("new primary header {:#?}", new_primary);
+    let new_backup =
+        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+    println!("new backup header {:#?}", new_backup);
+    new_primary
+        .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    new_backup
+        .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    let mbr = crate::mbr::ProtectiveMBR::new();
+    mbr.overwrite_lba0(&mut tempdisk).unwrap();
+    assert_eq!(h.signature, new_primary.signature);
+    assert_eq!(h.revision, new_primary.revision);
+    assert_eq!(h.header_size_le, new_primary.header_size_le);
+    assert_eq!(h.reserved, new_primary.reserved);
+    assert_eq!(h.current_lba, new_primary.current_lba);
+    assert_eq!(h.backup_lba, new_primary.backup_lba);
+    assert_eq!(34, new_primary.first_usable); // since we did not include the original header, the first usable defaults to 34
+    assert_eq!(h.last_usable, new_primary.last_usable);
+    assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
+    assert_eq!(2, new_primary.part_start);
+    //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
+    assert_eq!(0, new_primary.num_parts);
+    assert_eq!(128, new_primary.part_size); //standard size (it is possibly different, but usually 128)
+
+    let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();
+    //backup header tests
+    //current_lba and backup_lba should be flipped
+    assert_eq!(h.backup_lba, new_backup.current_lba);
+    assert_eq!(h.current_lba, new_backup.backup_lba);
+    // also, the backup header should match
+    assert_eq!(bh.current_lba, new_backup.current_lba);
+    assert_eq!(bh.backup_lba, new_backup.backup_lba);
+    assert_eq!(bh.part_start, new_backup.part_start);
+}
+
+#[test]
+// test compute new with fdisk'd image, giving original header
+// Note: if you would like to save to a file to check the headers
+// manually, use OpenOptions with write/create/truncate/read.  without the
+// read the checksum will not be able to read the tempdisk
+fn test_compute_new_fdisk_pass_header() {
+    let diskpath = Path::new("tests/fixtures/test.img");
+    let h = read_header(diskpath, disk::DEFAULT_SECTOR_SIZE).unwrap();
+    let cfg = crate::GptConfig::new().writable(false).initialized(true);
+    let disk = cfg.open(diskpath).unwrap();
+    println!("original Disk {:#?}", disk);
+    let partitions: BTreeMap<u32, partition::Partition> = BTreeMap::new();
+    let mut file = std::fs::OpenOptions::new()
+        .write(false)
+        .read(true)
+        .open(diskpath)
+        .unwrap();
+    let bak = find_backup_lba(&mut file, *disk.logical_block_size()).unwrap();
+    println!("Back offset {}", bak);
+    let mut tempdisk = tempfile::tempfile().expect("failed to create tempfile disk");
+    {
+        let data: [u8; 4096] = [0; 4096];
+        println!("Creating copy of test header file for testing");
+        for _ in 0..2560 {
+            tempdisk.write_all(&data).unwrap();
+        }
+    };
+    let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();
+    let mbr = crate::mbr::ProtectiveMBR::new();
+    mbr.overwrite_lba0(&mut tempdisk).unwrap();
+    let new_primary = Header::compute_new(
+        true,
+        &partitions,
+        uuid::Uuid::new_v4(),
+        bak,
+        &Some(h.clone()),
+    )
+    .unwrap();
+    println!("new primary header {:#?}", new_primary);
+    let new_backup = Header::compute_new(
+        false,
+        &partitions,
+        uuid::Uuid::new_v4(),
+        bak,
+        &Some(h.clone()),
+    )
+    .unwrap();
+    println!("new backup header {:#?}", new_backup);
+    new_primary
+        .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    println!("Hello");
+    new_backup
+        .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    assert_eq!(h.signature, new_primary.signature);
+    assert_eq!(h.revision, new_primary.revision);
+    assert_eq!(h.header_size_le, new_primary.header_size_le);
+    assert_eq!(h.reserved, new_primary.reserved);
+    assert_eq!(h.current_lba, new_primary.current_lba);
+    assert_eq!(h.backup_lba, new_primary.backup_lba);
+    assert_eq!(h.first_usable, new_primary.first_usable); // since we did not include the original header, the first usable defaults to 34
+    assert_eq!(h.last_usable, new_primary.last_usable);
+    assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
+    assert_eq!(2, new_primary.part_start);
+    //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
+    assert_eq!(h.num_parts, new_primary.num_parts);
+    assert_eq!(h.part_size, new_primary.part_size); //standard size (it is possibly different, but usually 128)
+
+    //backup header tests
+    //current_lba and backup_lba should be flipped
+    assert_eq!(h.backup_lba, new_backup.current_lba);
+    assert_eq!(h.current_lba, new_backup.backup_lba);
+    // also, the backup header should match
+    assert_eq!(bh.current_lba, new_backup.current_lba);
+    assert_eq!(bh.backup_lba, new_backup.backup_lba);
+    assert_eq!(bh.part_start, new_backup.part_start);
+}
+
+#[test]
+// test compute new with fdisk'd image, without giving original header
+fn test_compute_new_gpt_no_header() {
+    use tempfile;
+    let diskpath = Path::new("tests/fixtures/gpt-linux-disk-01.img");
+    let h = read_header(diskpath, disk::DEFAULT_SECTOR_SIZE).unwrap();
+    let cfg = crate::GptConfig::new().writable(false).initialized(true);
+    let disk = cfg.open(diskpath).unwrap();
+    println!("original Disk {:#?}", disk);
+    let partitions: BTreeMap<u32, partition::Partition> = BTreeMap::new();
+    let mut file = std::fs::OpenOptions::new()
+        .write(false)
+        .read(true)
+        .open(diskpath)
+        .unwrap();
+    let bak = find_backup_lba(&mut file, *disk.logical_block_size()).unwrap();
+    println!("Back offset {}", bak);
+    let mut tempdisk = tempfile::tempfile().expect("failed to create tempfile disk");
+    {
+        let data: [u8; 4096] = [0; 4096];
+        println!("Creating blank header file for testing");
+        for _ in 0..100 {
+            tempdisk.write_all(&data).unwrap();
+        }
+    };
+    let new_primary =
+        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+    println!("new primary header {:#?}", new_primary);
+    let new_backup =
+        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+    println!("new backup header {:#?}", new_backup);
+    new_primary
+        .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    new_backup
+        .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    let mbr = crate::mbr::ProtectiveMBR::new();
+    mbr.overwrite_lba0(&mut tempdisk).unwrap();
+    assert_eq!(h.signature, new_primary.signature);
+    assert_eq!(h.revision, new_primary.revision);
+    assert_eq!(h.header_size_le, new_primary.header_size_le);
+    assert_eq!(h.reserved, new_primary.reserved);
+    assert_eq!(h.current_lba, new_primary.current_lba);
+    assert_eq!(h.backup_lba, new_primary.backup_lba);
+    assert_eq!(34, new_primary.first_usable); // since we did not include the original header, the first usable defaults to 34
+    assert_eq!(h.last_usable, new_primary.last_usable);
+    assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
+    assert_eq!(2, new_primary.part_start);
+    //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
+    assert_eq!(0, new_primary.num_parts);
+    assert_eq!(128, new_primary.part_size); //standard size (it is possibly different, but usually 128)
+
+    let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();
+    //backup header tests
+    //current_lba and backup_lba should be flipped
+    assert_eq!(h.backup_lba, new_backup.current_lba);
+    assert_eq!(h.current_lba, new_backup.backup_lba);
+    // also, the backup header should match
+    assert_eq!(bh.current_lba, new_backup.current_lba);
+    assert_eq!(bh.backup_lba, new_backup.backup_lba);
+    assert_eq!(bh.part_start, new_backup.part_start);
+}
+
+#[test]
+// test compute new with fdisk'd image, giving original header
+// Note: if you would like to save to a file to check the headers
+// manually, use OpenOptions with write/create/truncate/read.  without the
+// read the checksum will not be able to read the tempdisk
+fn test_compute_new_fdisk_gpt_header() {
+    let diskpath = Path::new("tests/fixtures/gpt-linux-disk-01.img");
+    let h = read_header(diskpath, disk::DEFAULT_SECTOR_SIZE).unwrap();
+    let cfg = crate::GptConfig::new().writable(false).initialized(true);
+    let disk = cfg.open(diskpath).unwrap();
+    println!("original Disk {:#?}", disk);
+    let partitions: BTreeMap<u32, partition::Partition> = BTreeMap::new();
+    let mut file = std::fs::OpenOptions::new()
+        .write(false)
+        .read(true)
+        .open(diskpath)
+        .unwrap();
+    let bak = find_backup_lba(&mut file, *disk.logical_block_size()).unwrap();
+    println!("Back offset {}", bak);
+    let mut tempdisk = tempfile::tempfile().expect("failed to create tempfile disk");
+    {
+        let data: [u8; 4096] = [0; 4096];
+        println!("Creating copy of test header file for testing");
+        for _ in 0..2560 {
+            tempdisk.write_all(&data).unwrap();
+        }
+    };
+    let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();
+    let mbr = crate::mbr::ProtectiveMBR::new();
+    mbr.overwrite_lba0(&mut tempdisk).unwrap();
+    let new_primary = Header::compute_new(
+        true,
+        &partitions,
+        uuid::Uuid::new_v4(),
+        bak,
+        &Some(h.clone()),
+    )
+    .unwrap();
+    println!("new primary header {:#?}", new_primary);
+    let new_backup = Header::compute_new(
+        false,
+        &partitions,
+        uuid::Uuid::new_v4(),
+        bak,
+        &Some(h.clone()),
+    )
+    .unwrap();
+    println!("new backup header {:#?}", new_backup);
+    new_primary
+        .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    println!("Hello");
+    new_backup
+        .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .unwrap();
+    assert_eq!(h.signature, new_primary.signature);
+    assert_eq!(h.revision, new_primary.revision);
+    assert_eq!(h.header_size_le, new_primary.header_size_le);
+    assert_eq!(h.reserved, new_primary.reserved);
+    assert_eq!(h.current_lba, new_primary.current_lba);
+    assert_eq!(h.backup_lba, new_primary.backup_lba);
+    assert_eq!(h.first_usable, new_primary.first_usable); // since we did not include the original header, the first usable defaults to 34
+    assert_eq!(h.last_usable, new_primary.last_usable);
+    assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
+    assert_eq!(2, new_primary.part_start);
+    //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
+    assert_eq!(h.num_parts, new_primary.num_parts);
+    assert_eq!(h.part_size, new_primary.part_size); //standard size (it is possibly different, but usually 128)
+
+    //backup header tests
+    //current_lba and backup_lba should be flipped
+    assert_eq!(h.backup_lba, new_backup.current_lba);
+    assert_eq!(h.current_lba, new_backup.backup_lba);
+    // also, the backup header should match
+    assert_eq!(bh.current_lba, new_backup.current_lba);
+    assert_eq!(bh.backup_lba, new_backup.backup_lba);
+    assert_eq!(bh.part_start, new_backup.part_start);
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -552,7 +552,6 @@ fn test_compute_new_fdisk_pass_header() {
     new_primary
         .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
         .unwrap();
-    println!("Hello");
     new_backup
         .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
         .unwrap();
@@ -695,7 +694,6 @@ fn test_compute_new_fdisk_gpt_header() {
     new_primary
         .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
         .unwrap();
-    println!("Hello");
     new_backup
         .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ impl GptDisk {
         // Find the lowest lba that is larger than size.
         let free_sections = self.find_free_sectors();
         for (starting_lba, length) in free_sections {
+            debug!("starting_lba {}, length {}", starting_lba, length);
             if length >= size_lba {
                 // Found our free slice.
                 let partition_id = self.find_next_partition_id();
@@ -264,7 +265,7 @@ impl GptDisk {
 
     /// Find next highest partition id.
     pub fn find_next_partition_id(&self) -> u32 {
-        match self
+        let max = match self
             .partitions()
             .iter()
             // Skip unused partitions.
@@ -272,10 +273,16 @@ impl GptDisk {
             // Find the maximum id.
             .max_by_key(|x| x.0)
         {
-            Some(i) => i.0 + 1,
+            Some(i) => i.0 + 0,
             // Partitions start at 1.
             None => 1,
+        };
+        for i in 0..max {
+            if self.partitions().get(&i).is_none() {
+                return i;
+            }
         }
+        max + 1
     }
 
     /// Retrieve primary header, if any.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl GptDisk {
         let free_sections = self.find_free_sectors();
         for (starting_lba, length) in free_sections {
             debug!("starting_lba {}, length {}", starting_lba, length);
-            if length >= size_lba {
+            if length >= (size_lba - 1) {
                 // Found our free slice.
                 let partition_id = self.find_next_partition_id();
                 debug!(
@@ -185,13 +185,13 @@ impl GptDisk {
                     partition_id,
                     part_type,
                     starting_lba,
-                    starting_lba + size_lba as u64
+                    starting_lba + size_lba - 1 as u64
                 );
                 let part = partition::Partition {
                     part_type_guid: part_type,
                     part_guid: uuid::Uuid::new_v4(),
                     first_lba: starting_lba,
-                    last_lba: starting_lba + size_lba as u64,
+                    last_lba: starting_lba + size_lba - 1 as u64,
                     flags,
                     name: name.to_string(),
                 };
@@ -242,21 +242,27 @@ impl GptDisk {
     pub fn find_free_sectors(&self) -> Vec<(u64, u64)> {
         if let Some(header) = self.primary_header().or_else(|| self.backup_header()) {
             trace!("first_usable: {}", header.first_usable);
-            let mut disk_positions = vec![header.first_usable + 1];
+            let mut disk_positions = vec![header.first_usable];
             for part in self.partitions().iter().filter(|p| p.1.is_used()) {
                 trace!("partition: ({}, {})", part.1.first_lba, part.1.last_lba);
                 disk_positions.push(part.1.first_lba);
                 disk_positions.push(part.1.last_lba);
             }
-            disk_positions.push(header.last_usable - 1);
+            disk_positions.push(header.last_usable);
             trace!("last_usable: {}", header.last_usable);
             disk_positions.sort();
 
             return disk_positions
                 // Walk through the LBA's in chunks of 2 (ending, starting).
                 .chunks(2)
-                // Add 1 to the ending and then subtract the starting.
-                .map(|p| (p[0] + 1, p[1].saturating_sub(p[0])))
+                // Add 1 to the ending and then subtract the starting if NOT the first usable sector
+                .map(|p| {
+                    if p[0] != header.first_usable {
+                        (p[0] + 1, p[1].saturating_sub(p[0] + 1))
+                    } else {
+                        (p[0], p[1].saturating_sub(p[0]))
+                    }
+                })
                 .collect();
         }
         // No primary header. Return nothing.
@@ -275,9 +281,9 @@ impl GptDisk {
         {
             Some(i) => i.0 + 0,
             // Partitions start at 1.
-            None => 1,
+            None => return 1,
         };
-        for i in 0..max {
+        for i in 1..max {
             if self.partitions().get(&i).is_none() {
                 return i;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,8 +329,8 @@ impl GptDisk {
     ) -> io::Result<&Self> {
         // TODO(lucab): validate partitions.
         let bak = header::find_backup_lba(&mut self.file, self.config.lb_size)?;
-        let h1 = header::Header::compute_new(true, &pp, self.guid, bak)?;
-        let h2 = header::Header::compute_new(false, &pp, self.guid, bak)?;
+        let h1 = header::Header::compute_new(true, &pp, self.guid, bak, &self.primary_header)?;
+        let h2 = header::Header::compute_new(false, &pp, self.guid, bak, &self.backup_header)?;
         self.primary_header = Some(h1);
         self.backup_header = Some(h2);
         self.partitions = pp;
@@ -366,10 +366,20 @@ impl GptDisk {
                 self.config.lb_size,
             )?;
         }
-        let new_backup_header =
-            header::Header::compute_new(false, &self.partitions, self.guid, bak)?;
-        let new_primary_header =
-            header::Header::compute_new(true, &self.partitions, self.guid, bak)?;
+        let new_backup_header = header::Header::compute_new(
+            false,
+            &self.partitions,
+            self.guid,
+            bak,
+            &self.primary_header,
+        )?;
+        let new_primary_header = header::Header::compute_new(
+            true,
+            &self.partitions,
+            self.guid,
+            bak,
+            &self.backup_header,
+        )?;
         debug!("Writing backup header");
         new_backup_header.write_backup(&mut self.file, self.config.lb_size)?;
         debug!("Writing primary header");

--- a/tests/fixtures/gpt-headers.txt
+++ b/tests/fixtures/gpt-headers.txt
@@ -1,0 +1,36 @@
+sudo dd if=gpt/tests/fixtures/gpt-linux-disk-01.img bs=512 count=1 skip=1 > lba.1
+Primary Header of gpt-linux-disk-01.img
+------------------------------------------
+Signature:              0x4546492050415254
+Revision:                       0x00000100
+HeaderSize:                             92
+HeaderCRC32:                    0x3e9607da
+HeaderCRC32 (calculated):       0x3e9607da
+Reserved:                       0x00000000
+MyLBA:                                   1
+AlternateLBA:                           95
+FirstUsableLBA:                         34
+LastUsableLBA:                          62
+PartitionEntryLBA:                       2
+NumberOfPartitionEntries:              128
+SizeOfPartitionEntry:                  128
+PartitionEntryArrayCRC32:        0x90e9ba6
+
+==========================================
+sudo dd if=gpt/tests/fixtures/gpt-linux-disk-01.img bs=512 count=1 skip=95 > lba.last
+Backup Header
+------------------------------------------
+Signature:              0x4546492050415254
+Revision:                       0x00000100
+HeaderSize:                             92
+HeaderCRC32:                    0xeacc533e
+HeaderCRC32 (calculated):       0xeacc533e
+Reserved:                       0x00000000
+MyLBA:                                  95
+AlternateLBA:                            1
+FirstUsableLBA:                         34
+LastUsableLBA:                          62
+PartitionEntryLBA:                      63
+NumberOfPartitionEntries:              128
+SizeOfPartitionEntry:                  128
+PartitionEntryArrayCRC32:        0x90e9ba6

--- a/tests/fixtures/test-headers.txt
+++ b/tests/fixtures/test-headers.txt
@@ -1,0 +1,36 @@
+sudo dd if=gpt/tests/fixtures/test.img bs=512 count=1 skip=1 > lba.1
+Primary Header of test.img
+------------------------------------------
+Signature:              0x4546492050415254
+Revision:                       0x00000100
+HeaderSize:                             92
+HeaderCRC32:                    0x24929e70
+HeaderCRC32 (calculated):       0x24929e70
+Reserved:                       0x00000000
+MyLBA:                                   1
+AlternateLBA:                        20479
+FirstUsableLBA:                       2048
+LastUsableLBA:                       20446
+PartitionEntryLBA:                       2
+NumberOfPartitionEntries:              128
+SizeOfPartitionEntry:                  128
+PartitionEntryArrayCRC32:       0xd9c4150d
+
+==========================================
+sudo dd if=gpt/tests/fixtures/test.img bs=512 count=1 skip=20479 > lba.last
+Backup Header
+------------------------------------------
+Signature:              0x4546492050415254
+Revision:                       0x00000100
+HeaderSize:                             92
+HeaderCRC32:                    0x9e29fd39
+HeaderCRC32 (calculated):       0x9e29fd39
+Reserved:                       0x00000000
+MyLBA:                               20479
+AlternateLBA:                            1
+FirstUsableLBA:                       2048
+LastUsableLBA:                       20446
+PartitionEntryLBA:                   20447
+NumberOfPartitionEntries:              128
+SizeOfPartitionEntry:                  128
+PartitionEntryArrayCRC32:       0xd9c4150d


### PR DESCRIPTION
When writing to disk header, give old header (if exists) to compute new to keep the first_usable and last_usable attributes so as to not break the GPT (partprobe will complaing about not using all space available.  Especially since the first_usable is not always sector 34.  In fact, it is usually 2048 in order to align partition boundaries. Otherwise, if the original headers are not given, use the default values.
Also, fix getting the next partition number so that it gets the first USABLE partition number, NOT the next highest partition number, and fix find_free_sectors so that if creating a partition, it can start from the first usable sector (aka 2048 usually, this starts the partition at the physical sector boundary so a blank disk getting partitioned won't complain about not starting at the physical sector boundary)