### PR TITLE
The partition names are null-terminated.

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -182,7 +182,9 @@ fn read_part_name(rdr: &mut Cursor<&[u8]>) -> Result<String> {
         let b = u16::from_le_bytes(read_exact_buff!(bbuff, rdr, 2));
         if b != 0 {
             namebytes.push(b);
-        }
+        } else {
+	    break;
+	}
     }
 
     Ok(String::from_utf16_lossy(&namebytes))


### PR DESCRIPTION
Realized this when gpt was returning "BOOTry" for the partition name where parted and everything else just shows "BOOT".