### PR TITLE
Header and partition zeroization fixes

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -178,7 +178,9 @@ impl Header {
             .ok_or_else(|| Error::new(ErrorKind::Other, "header overflow - offset"))?;
         trace!("Seeking to {}", start);
         let _ = file.seek(SeekFrom::Start(start))?;
-        let len = file.write(&self.as_bytes(Some(checksum), Some(parts_checksum))?)?;
+        let mut buff = self.as_bytes(Some(checksum), Some(parts_checksum))?;
+        buff.resize(512,0);
+        let len = file.write(&buff)?;
         trace!("Wrote {} bytes", len);
 
         Ok(len)

--- a/src/header.rs
+++ b/src/header.rs
@@ -12,7 +12,8 @@ use uuid;
 use crate::disk;
 use crate::partition;
 
-const GPT_MIN_NUM_PARTITIONS : u32 = 128;
+/// Minimum number of partition table entries
+pub const GPT_MIN_NUM_PARTITION_ENTRIES : u32 = 128;
 
 /// Header describing a GPT disk.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -95,7 +96,7 @@ impl Header {
             // UEFI requires space for 128 minimum, but the number can be increased or reduced
             num_parts: match original_header {
                 Some(header) => header.num_parts,
-                None => GPT_MIN_NUM_PARTITIONS
+                None => GPT_MIN_NUM_PARTITION_ENTRIES
             },
             //though usually 128, it might be a different number
             part_size: match original_header {
@@ -494,7 +495,7 @@ fn test_compute_new_fdisk_no_header() {
     assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
     assert_eq!(2, new_primary.part_start);
     //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
-    assert_eq!(GPT_MIN_NUM_PARTITIONS, new_primary.num_parts);
+    assert_eq!(GPT_MIN_NUM_PARTITION_ENTRIES, new_primary.num_parts);
     assert_eq!(128, new_primary.part_size); //standard size (it is possibly different, but usually 128)
 
     let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();
@@ -636,7 +637,7 @@ fn test_compute_new_gpt_no_header() {
     assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
     assert_eq!(2, new_primary.part_start);
     //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
-    assert_eq!(GPT_MIN_NUM_PARTITIONS, new_primary.num_parts);
+    assert_eq!(GPT_MIN_NUM_PARTITION_ENTRIES, new_primary.num_parts);
     assert_eq!(128, new_primary.part_size); //standard size (it is possibly different, but usually 128)
 
     let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,9 +371,10 @@ impl GptDisk {
         trace!("old backup header: {:?}", self.backup_header);
         let bak = header::find_backup_lba(&mut self.file, self.config.lb_size)?;
         trace!("old backup lba: {}", bak);
-        trace!("Number of partitions to write: {}",self.partitions().len());
+	let num_defined_parts = self.partitions().len() as u32;
+        trace!("Number of partitions to write: {}",num_defined_parts);
         let zerop = partition::Partition::zero();
-        let num_parts = 128 as u32; // XXX
+        let num_parts = header::GPT_MIN_NUM_PARTITION_ENTRIES.max(num_defined_parts) as u32;
         for i in 0..num_parts {
             let partition =
                 match self.partitions.get(&i) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,10 +371,18 @@ impl GptDisk {
         trace!("old backup header: {:?}", self.backup_header);
         let bak = header::find_backup_lba(&mut self.file, self.config.lb_size)?;
         trace!("old backup lba: {}", bak);
-        for partition in self.partitions().iter().filter(|p| p.1.is_used()) {
-            partition.1.write(
+        trace!("Number of partitions to write: {}",self.partitions().len());
+        let zerop = partition::Partition::zero();
+        let num_parts = 128 as u32; // XXX
+        for i in 0..num_parts {
+            let partition =
+                match self.partitions.get(&i) {
+                    None => &zerop,
+                    Some(p) => &p
+                };
+            partition.write(
                 &self.path,
-                u64::from(partition.0.checked_sub(1).unwrap_or_else(|| 0)),
+                i as u64,
                 self.primary_header.clone().unwrap().part_start,
                 self.config.lb_size,
             )?;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -182,7 +182,9 @@ fn read_part_name(rdr: &mut Cursor<&[u8]>) -> Result<String> {
         let b = u16::from_le_bytes(read_exact_buff!(bbuff, rdr, 2));
         if b != 0 {
             namebytes.push(b);
-        }
+        } else {
+	    break;
+	}
     }
 
     Ok(String::from_utf16_lossy(&namebytes))


### PR DESCRIPTION
Hi,

I've run into problems on systems with pre-existing partitions and made some changes.  The deleted entries were not zeroized.  I fixed that, and comparing with the fdisk code it's clear that the table should be at least 128 entries long so I made that clear in the code.

Also I've noticed that the reserved portion of the headers is not set to zero.  After fixing that I had to adjust one test to ensure that the created file was large enough.
