### PR TITLE
Support for arbitrary devices & other various enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 language: rust
 rust:
-  - 1.32.0  # pinned toolchain for clippy
-  - 1.32.0  # minimum supported toolchain
+  - 1.34.0  # pinned toolchain for clippy
+  - 1.34.0  # minimum supported toolchain
   - stable
   - beta
   - nightly
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=1.31.1
+    - CLIPPY_RUST_VERSION=1.34.0
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Quyzi/gpt.svg?branch=master)](https://travis-ci.org/Quyzi/gpt)
 [![crates.io](https://img.shields.io/crates/v/gpt.svg)](https://crates.io/crates/gpt)
-![minimum rust 1.32](https://img.shields.io/badge/rust-1.32%2B-orange.svg)
+![minimum rust 1.34](https://img.shields.io/badge/rust-1.34%2B-orange.svg)
 [![Documentation](https://docs.rs/gpt/badge.svg)](https://docs.rs/gpt)
 
 A pure-Rust library to work with GPT partition tables.

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -1,7 +1,7 @@
 //! Disk-related types and helper functions.
 
 use super::{GptConfig, GptDisk};
-use std::{fmt, io, path};
+use std::{convert::TryFrom, fmt, io, path};
 
 /// Default size of a logical sector (bytes).
 pub const DEFAULT_SECTOR_SIZE: LogicalBlockSize = LogicalBlockSize::Lb512;
@@ -33,11 +33,25 @@ impl Into<usize> for LogicalBlockSize {
     }
 }
 
+impl TryFrom<u64> for LogicalBlockSize {
+    type Error = io::Error;
+    fn try_from(v: u64) -> Result<Self, Self::Error> {
+        match v {
+            512 => Ok(LogicalBlockSize::Lb512),
+            4096 => Ok(LogicalBlockSize::Lb4096),
+            _ => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "unsupported logical block size (must be 512 or 4096)"
+            )),
+        }
+    }
+}
+
 impl fmt::Display for LogicalBlockSize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             LogicalBlockSize::Lb512 => write!(f, "512"),
-            LogicalBlockSize::Lb4096 => write!(f, "1096"),
+            LogicalBlockSize::Lb4096 => write!(f, "4096"),
         }
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -178,7 +178,10 @@ impl Header {
             .ok_or_else(|| Error::new(ErrorKind::Other, "header overflow - offset"))?;
         trace!("Seeking to {}", start);
         let _ = file.seek(SeekFrom::Start(start))?;
-        let len = file.write(&self.as_bytes(Some(checksum), Some(parts_checksum))?)?;
+        let mut header_bytes = self.as_bytes(Some(checksum), Some(parts_checksum))?;
+        // Per the spec, the rest of the logical block must be zeros...
+        header_bytes.resize(Into::<usize>::into(lb_size), 0x00);
+        let len = file.write(&header_bytes)?;
         trace!("Wrote {} bytes", len);
 
         Ok(len)

--- a/src/header.rs
+++ b/src/header.rs
@@ -75,7 +75,7 @@ impl Header {
             None => 128,
         };
 
-        let part_array_num_bytes = (num_parts * part_size) as u64;
+        let part_array_num_bytes = u64::from(num_parts * part_size);
         // If not an exact multiple of a sector, round up to the next # of whole sectors.
         let lb_size_u64 = Into::<u64>::into(lb_size);
         let part_array_num_lbs = (part_array_num_bytes + (lb_size_u64 - 1)) / lb_size_u64;

--- a/src/header.rs
+++ b/src/header.rs
@@ -52,26 +52,49 @@ impl Header {
         guid: uuid::Uuid,
         backup_offset: u64,
         original_header: &Option<Header>,
+        lb_size: disk::LogicalBlockSize,
     ) -> Result<Self> {
         let (cur, bak) = if primary {
             (1, backup_offset)
         } else {
             (backup_offset, 1)
         };
+
+        // really this number should actually usually be 128, as it is the
+        // TOTAL number of entries in the partition table, NOT the number USED.
+        // UEFI requires space for 128 minimum, but the number can be increased or reduced.
+        // If we're creating the table from scratch, make sure the table contains enough
+        // room to be UEFI compliant.
+        let num_parts = match original_header {
+            Some(header) => header.num_parts,
+            None => (pp.iter().filter(|p| p.1.is_used()).count() as u32).max(128),
+        };
+        //though usually 128, it might be a different number
+        let part_size = match original_header {
+            Some(header) => header.part_size,
+            None => 128,
+        };
+
+        let part_array_num_bytes = (num_parts * part_size) as u64;
+        // If not an exact multiple of a sector, round up to the next # of whole sectors.
+        let lb_size_u64 = Into::<u64>::into(lb_size);
+        let part_array_num_lbs = (part_array_num_bytes + (lb_size_u64 - 1)) / lb_size_u64;
+
         // sometimes the first usable isn't sector 34, fdisk starts at 2048
+        // alternatively, if the sector size is 4096 it might not be 34 either.
         // to align partition boundaries (https://metebalci.com/blog/a-quick-tour-of-guid-partition-table-gpt/)
         let first = match original_header {
             Some(header) => header.first_usable,
-            None => 34u64,
+            None => 1 + 1 + part_array_num_lbs, //protective MBR + GPT header + partition array
         };
         let last = match original_header {
             Some(header) => header.last_usable,
             None => {
+                // last is inclusive: end of disk is (partition array) (backup header)
                 backup_offset
-                    .checked_sub(first)
+                    .checked_sub(part_array_num_lbs + 1)
                     .ok_or_else(|| Error::new(ErrorKind::Other, "header underflow - last usable"))?
-                    + 1
-            } // its the alternate_lba (aka backup offset) - first_usable + 1, because LBA starts from 0
+            }
         };
         // the partition entry LBA starts at 2 (usually) for primary headers and at the last_usable + 1 for backup headers
         let part_start = if primary { 2 } else { last + 1 };
@@ -88,18 +111,8 @@ impl Header {
             last_usable: last,
             disk_guid: guid,
             part_start,
-            // really this number should actually usually be 128, as it is the
-            // TOTAL number of entries in the partition table, NOT the number USED.
-            // UEFI requires space for 128 minimum, but the number can be increased or reduced
-            num_parts: match original_header {
-                Some(header) => header.num_parts,
-                None => pp.iter().filter(|p| p.1.is_used()).count() as u32,
-            },
-            //though usually 128, it might be a different number
-            part_size: match original_header {
-                Some(header) => header.part_size,
-                None => 128,
-            },
+            num_parts,
+            part_size,
             crc32_parts: 0,
         };
 
@@ -433,7 +446,7 @@ pub fn write_header(
         }
     };
 
-    let hdr = Header::compute_new(true, &BTreeMap::new(), guid, bak, &None)?;
+    let hdr = Header::compute_new(true, &BTreeMap::new(), guid, bak, &None, sector_size)?;
     debug!("new header: {:#?}", hdr);
     hdr.write_primary(&mut file, sector_size)?;
 
@@ -444,8 +457,9 @@ pub fn write_header(
 // test compute new with fdisk'd image, without giving original header
 fn test_compute_new_fdisk_no_header() {
     use tempfile;
+    let lb_size = disk::DEFAULT_SECTOR_SIZE;
     let diskpath = Path::new("tests/fixtures/test.img");
-    let h = read_header(diskpath, disk::DEFAULT_SECTOR_SIZE).unwrap();
+    let h = read_header(diskpath, lb_size).unwrap();
     let cfg = crate::GptConfig::new().writable(false).initialized(true);
     let disk = cfg.open(diskpath).unwrap();
     println!("original Disk {:#?}", disk);
@@ -461,21 +475,24 @@ fn test_compute_new_fdisk_no_header() {
     {
         let data: [u8; 4096] = [0; 4096];
         println!("Creating blank header file for testing");
-        for _ in 0..100 {
+        // This should be large enough to contain the backup partition array,
+        // or computing the checksum when writing the backup header will fail.
+        let min_file_size = (bak * Into::<u64>::into(lb_size)) + Into::<u64>::into(lb_size);
+        for _ in 0..((min_file_size + 4095) / 4096) {
             tempdisk.write_all(&data).unwrap();
         }
     };
     let new_primary =
-        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
     println!("new primary header {:#?}", new_primary);
     let new_backup =
-        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
     println!("new backup header {:#?}", new_backup);
     new_primary
-        .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .write_primary(&mut tempdisk, lb_size)
         .unwrap();
     new_backup
-        .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .write_backup(&mut tempdisk, lb_size)
         .unwrap();
     let mbr = crate::mbr::ProtectiveMBR::new();
     mbr.overwrite_lba0(&mut tempdisk).unwrap();
@@ -489,8 +506,8 @@ fn test_compute_new_fdisk_no_header() {
     assert_eq!(h.last_usable, new_primary.last_usable);
     assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
     assert_eq!(2, new_primary.part_start);
-    //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
-    assert_eq!(0, new_primary.num_parts);
+    // when creating a new table from scratch, we should always have a minimum of 128 entries to be UEFI compliant
+    assert_eq!(128, new_primary.num_parts);
     assert_eq!(128, new_primary.part_size); //standard size (it is possibly different, but usually 128)
 
     let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();
@@ -540,6 +557,7 @@ fn test_compute_new_fdisk_pass_header() {
         uuid::Uuid::new_v4(),
         bak,
         &Some(h.clone()),
+        disk::DEFAULT_SECTOR_SIZE,
     )
     .unwrap();
     println!("new primary header {:#?}", new_primary);
@@ -549,6 +567,7 @@ fn test_compute_new_fdisk_pass_header() {
         uuid::Uuid::new_v4(),
         bak,
         &Some(h.clone()),
+        disk::DEFAULT_SECTOR_SIZE,
     )
     .unwrap();
     println!("new backup header {:#?}", new_backup);
@@ -586,8 +605,9 @@ fn test_compute_new_fdisk_pass_header() {
 // test compute new with fdisk'd image, without giving original header
 fn test_compute_new_gpt_no_header() {
     use tempfile;
+    let lb_size = disk::DEFAULT_SECTOR_SIZE;
     let diskpath = Path::new("tests/fixtures/gpt-linux-disk-01.img");
-    let h = read_header(diskpath, disk::DEFAULT_SECTOR_SIZE).unwrap();
+    let h = read_header(diskpath, lb_size).unwrap();
     let cfg = crate::GptConfig::new().writable(false).initialized(true);
     let disk = cfg.open(diskpath).unwrap();
     println!("original Disk {:#?}", disk);
@@ -608,16 +628,16 @@ fn test_compute_new_gpt_no_header() {
         }
     };
     let new_primary =
-        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
     println!("new primary header {:#?}", new_primary);
     let new_backup =
-        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None).unwrap();
+        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
     println!("new backup header {:#?}", new_backup);
     new_primary
-        .write_primary(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .write_primary(&mut tempdisk, lb_size)
         .unwrap();
     new_backup
-        .write_backup(&mut tempdisk, disk::DEFAULT_SECTOR_SIZE)
+        .write_backup(&mut tempdisk, lb_size)
         .unwrap();
     let mbr = crate::mbr::ProtectiveMBR::new();
     mbr.overwrite_lba0(&mut tempdisk).unwrap();
@@ -631,8 +651,8 @@ fn test_compute_new_gpt_no_header() {
     assert_eq!(h.last_usable, new_primary.last_usable);
     assert_ne!(h.disk_guid, new_primary.disk_guid); //writing new disk => new guid
     assert_eq!(2, new_primary.part_start);
-    //if we do a write disk this wouldn't actually be able to write a new partition with fdisk unless you created a new partition table on it
-    assert_eq!(0, new_primary.num_parts);
+    // when creating a new table from scratch, we should always have a minimum of 128 entries to be UEFI compliant
+    assert_eq!(128, new_primary.num_parts);
     assert_eq!(128, new_primary.part_size); //standard size (it is possibly different, but usually 128)
 
     let bh = read_backup_header(&mut file, *disk.logical_block_size()).unwrap();
@@ -682,6 +702,7 @@ fn test_compute_new_fdisk_gpt_header() {
         uuid::Uuid::new_v4(),
         bak,
         &Some(h.clone()),
+        disk::DEFAULT_SECTOR_SIZE,
     )
     .unwrap();
     println!("new primary header {:#?}", new_primary);
@@ -691,6 +712,7 @@ fn test_compute_new_fdisk_gpt_header() {
         uuid::Uuid::new_v4(),
         bak,
         &Some(h.clone()),
+        disk::DEFAULT_SECTOR_SIZE,
     )
     .unwrap();
     println!("new backup header {:#?}", new_backup);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,17 @@ impl GptDisk {
         &self.config.lb_size
     }
 
+    /// Change the disk device that we are reading/writing from/to.
+    /// Returns the previous disk device.
+    pub fn update_disk_device(
+        &mut self,
+        device: DiskDeviceObject,
+        writable: bool
+    ) -> DiskDeviceObject {
+        self.config.writable = writable;
+        std::mem::replace(&mut self.device, device)
+    }
+
     /// Update disk UUID.
     ///
     /// If no UUID is specified, a new random one is generated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,8 +377,10 @@ impl GptDisk {
     ) -> io::Result<&Self> {
         // TODO(lucab): validate partitions.
         let bak = header::find_backup_lba(&mut self.device, self.config.lb_size)?;
-        let h1 = header::Header::compute_new(true, &pp, self.guid, bak, &self.primary_header)?;
-        let h2 = header::Header::compute_new(false, &pp, self.guid, bak, &self.backup_header)?;
+        let h1 = header::Header::compute_new(
+            true, &pp, self.guid, bak, &self.primary_header, self.config.lb_size)?;
+        let h2 = header::Header::compute_new(
+            false, &pp, self.guid, bak, &self.backup_header, self.config.lb_size)?;
         self.primary_header = Some(h1);
         self.backup_header = Some(h2);
         self.partitions = pp;
@@ -447,6 +449,7 @@ impl GptDisk {
             self.guid,
             bak,
             &self.primary_header,
+            self.config.lb_size,
         )?;
         let new_primary_header = header::Header::compute_new(
             true,
@@ -454,6 +457,7 @@ impl GptDisk {
             self.guid,
             bak,
             &self.backup_header,
+            self.config.lb_size,
         )?;
         debug!("Writing backup header");
         new_backup_header.write_backup(&mut self.device, self.config.lb_size)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //!     // Create a protective MBR at LBA0
 //!     let mbr = gpt::mbr::ProtectiveMBR::with_lb_size(
-//!         u32::try_from(TOTAL_BYTES / 512).unwrap_or(0xFF_FF_FF_FF));
+//!         u32::try_from((TOTAL_BYTES / 512) - 1).unwrap_or(0xFF_FF_FF_FF));
 //!     mbr.overwrite_lba0(&mut mem_device).expect("failed to write MBR");
 //!
 //!     let mut gdisk = gpt::GptConfig::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ impl<'a> GptDisk<'a> {
             // Find the maximum id.
             .max_by_key(|x| x.0)
         {
-            Some(i) => i.0 + 0,
+            Some(i) => *i.0,
             // Partitions start at 1.
             None => return 1,
         };
@@ -468,7 +468,7 @@ impl<'a> GptDisk<'a> {
         let mut next_partition_index = 0u64;
         for partition in self.partitions().clone().iter().filter(|p| p.1.is_used()) {
             // don't allow us to overflow partition array...
-            if next_partition_index >= primary_header.num_parts as u64 {
+            if next_partition_index >= u64::from(primary_header.num_parts) {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
                     format!("attempting to write more than max of {} partitions in primary array",
@@ -488,7 +488,7 @@ impl<'a> GptDisk<'a> {
             // area to store the partition array; otherwise backup header will not point
             // to an up to date partition array on disk.
             if let Some(backup_header) = backup_header.as_ref() {
-                if next_partition_index >= backup_header.num_parts as u64 {
+                if next_partition_index >= u64::from(backup_header.num_parts) {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
                         format!("attempting to write more than max of {} partitions in backup array",
@@ -514,7 +514,7 @@ impl<'a> GptDisk<'a> {
         partition::Partition::write_zero_entries_to_device(
             &mut self.device,
             next_partition_index,
-            (primary_header.num_parts as u64).checked_sub(next_partition_index).unwrap(),
+            u64::from(primary_header.num_parts).checked_sub(next_partition_index).unwrap(),
             primary_header.part_start,
             self.config.lb_size,
             primary_header.part_size,
@@ -523,7 +523,7 @@ impl<'a> GptDisk<'a> {
             partition::Partition::write_zero_entries_to_device(
                 &mut self.device,
                 next_partition_index,
-                (backup_header.num_parts as u64).checked_sub(next_partition_index).unwrap(),
+                u64::from(backup_header.num_parts).checked_sub(next_partition_index).unwrap(),
                 backup_header.part_start,
                 self.config.lb_size,
                 backup_header.part_size,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,6 +38,7 @@ pub mod pub_macros {
                 match s {
                     $(
                         $guid => Ok($upcase),
+                        stringify!($upcase) => Ok($upcase),
                     )+
                     _ => Err("Invalid or unknown Partition Type GUID.".to_string()),
                 }

--- a/src/mbr.rs
+++ b/src/mbr.rs
@@ -168,18 +168,26 @@ impl ProtectiveMBR {
         self
     }
 
-    /// Returns the given partition (0..=3). Panics if the partition index is invalid.
-    pub fn partition(&self, partition_index: usize) -> PartRecord {
-        self.partitions[partition_index]
+    /// Returns the given partition (0..=3) or None if the partition index is invalid.
+    pub fn partition(&self, partition_index: usize) -> Option<PartRecord> {
+        if partition_index >= self.partitions.len() {
+            None
+        } else {
+            Some(self.partitions[partition_index])
+        }
     }
 
-    /// Set the data for the given partition. Panics if the index is invalid.
-    /// Returns the previous partition record.
+    /// Set the data for the given partition.
+    /// Returns the previous partition record or None if the partition index is invalid.
     ///
     /// This only changes the in-memory state, without overwriting
     /// any on-disk data.
-    pub fn set_partition(&mut self, partition_index: usize, partition: PartRecord) -> PartRecord {
-        std::mem::replace(&mut self.partitions[partition_index], partition)
+    pub fn set_partition(&mut self, partition_index: usize, partition: PartRecord) -> Option<PartRecord> {
+        if partition_index >= self.partitions.len() {
+            None
+        } else {
+            Some(std::mem::replace(&mut self.partitions[partition_index], partition))
+        }
     }
 
     /// Write a protective MBR to LBA0, overwriting any existing data.

--- a/src/mbr.rs
+++ b/src/mbr.rs
@@ -46,7 +46,9 @@ impl ProtectiveMBR {
         Self::default()
     }
 
-    /// Create a protective-MBR object with a specific disk size (in LB).
+    /// Create a protective-MBR object with a specific protective partition size (in LB).
+    /// The protective partition size should be the size of the disk - 1 (because the protective
+    /// partition always begins at LBA 1 (the second sector)).
     pub fn with_lb_size(lb_size: u32) -> Self {
         Self {
             bootcode: [0x00; 440],

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -128,7 +128,7 @@ impl Partition {
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition overflow - start offset"))?;
         // The offset is bytes_per_partition * partition_index
         let offset = partition_index
-            .checked_mul(bytes_per_partition as u64)
+            .checked_mul(u64::from(bytes_per_partition))
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition overflow"))?;
         trace!("seeking to partition start: {}", pstart + offset);
         device.seek(SeekFrom::Start(pstart + offset))?;
@@ -154,11 +154,11 @@ impl Partition {
             .checked_mul(lb_size.into())
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition overflow - start offset"))?;
         let offset = starting_partition_index
-            .checked_mul(bytes_per_partition as u64)
+            .checked_mul(u64::from(bytes_per_partition))
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition overflow"))?;
         trace!("seeking to starting partition start: {}", pstart + offset);
         device.seek(SeekFrom::Start(pstart + offset))?;
-        let bytes_to_zero = (bytes_per_partition as u64)
+        let bytes_to_zero = u64::from(bytes_per_partition)
             .checked_mul(number_entries)
             .and_then(|x| usize::try_from(x).ok())
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition overflow - bytes to zero"))?;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -7,6 +7,7 @@ use bitflags::*;
 use crc::crc32;
 use log::*;
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
@@ -17,6 +18,7 @@ use uuid;
 use crate::disk;
 use crate::header::{parse_uuid, Header};
 use crate::partition_types::Type;
+use crate::DiskDevice;
 
 bitflags! {
     /// Partition entry attributes, defined for UEFI.
@@ -61,7 +63,7 @@ impl Partition {
     }
 
     /// Serialize this partition entry to its bytes representation.
-    fn as_bytes(&self, entry_size: u16) -> Result<Vec<u8>> {
+    fn as_bytes(&self, entry_size: u32) -> Result<Vec<u8>> {
         let mut buf: Vec<u8> = Vec::with_capacity(entry_size as usize);
 
         // Type GUID.
@@ -92,32 +94,46 @@ impl Partition {
         }
 
         // Resize buffer to exact entry size.
-        buf.resize(entry_size as usize, 0x00);
+        buf.resize(usize::try_from(entry_size).unwrap(), 0x00);
 
         Ok(buf)
     }
 
-    /// Write the partition entry to the partitions area and update crc32 for the Header.
+    /// Write the partition entry to the partitions area in the given file.
+    /// NOTE: does not update partitions array crc32 in the headers!
     pub fn write(
         &self,
         p: &Path,
-        partition_id: u64,
+        partition_index: u64,
         start_lba: u64,
         lb_size: disk::LogicalBlockSize,
     ) -> Result<()> {
-        debug!("writing partition to: {}", p.display());
+        let mut file = OpenOptions::new().write(true).read(true).open(p)?;
+        self.write_to_device(&mut file, partition_index, start_lba, lb_size, 128)
+    }
+
+    /// Write the partition entry to the partitions area in the given device.
+    /// NOTE: does not update partitions array crc32 in the headers!
+    pub fn write_to_device<D: DiskDevice>(
+        &self,
+        device: &mut D,
+        partition_index: u64,
+        start_lba: u64,
+        lb_size: disk::LogicalBlockSize,
+        bytes_per_partition: u32,
+    ) -> Result<()> {
+        debug!("writing partition to: {:?}", device);
         let pstart = start_lba
             .checked_mul(lb_size.into())
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition overflow - start offset"))?;
-        let mut file = OpenOptions::new().write(true).read(true).open(p)?;
-        // The offset is 128 * partition_id
-        let offset = partition_id
-            .checked_mul(128)
+        // The offset is bytes_per_partition * partition_index
+        let offset = partition_index
+            .checked_mul(bytes_per_partition as u64)
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition overflow"))?;
         trace!("seeking to partition start: {}", pstart + offset);
-        file.seek(SeekFrom::Start(pstart + offset))?;
-        trace!("writing {:?}", &self.as_bytes(128));
-        file.write_all(&self.as_bytes(128)?)?;
+        device.seek(SeekFrom::Start(pstart + offset))?;
+        trace!("writing {:?}", &self.as_bytes(bytes_per_partition));
+        device.write_all(&self.as_bytes(bytes_per_partition)?)?;
 
         Ok(())
     }

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -88,9 +88,18 @@ impl FromStr for OperatingSystem {
 }
 
 #[test]
-fn test_partition_fromstr() {
+fn test_partition_fromstr_guid() {
     let p = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
     let t = Type::from_str(p).unwrap();
+    println!("result: {:?}", t);
+    assert_eq!(t, LINUX_FS);
+}
+
+#[test]
+fn test_partition_from_name() {
+    // mix case as part of the test
+    let p = "Linux_FS";
+    let t = Type::from_name(p).unwrap();
     println!("result: {:?}", t);
     assert_eq!(t, LINUX_FS);
 }
@@ -101,6 +110,13 @@ impl Type {
         let uuid_str = u.to_hyphenated().to_string().to_uppercase();
         trace!("looking up partition type guid {}", uuid_str);
         Type::from_str(&uuid_str)
+    }
+
+    /// Lookup a partition type by name
+    pub fn from_name(name: &str) -> Result<Self, String> {
+        let name_str = name.to_uppercase();
+        trace!("looking up partition type by name {}", name_str);
+        Type::from_str(&name_str)
     }
 }
 

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -1,6 +1,7 @@
 use gpt;
 
 use gpt::disk;
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::io::{SeekFrom, Write};
 use std::path;
@@ -97,4 +98,117 @@ fn test_gptdisk_linux_01_write_fidelity_with_device() {
     assert_eq!(gdisk_mem.primary_header().unwrap(), &good_header1);
     assert_eq!(gdisk_mem.backup_header().unwrap(), &good_header2);
     assert_eq!(gdisk_mem.partitions().clone(), good_partitions);
+}
+
+#[test]
+fn test_create_simple_on_device() {
+    const TOTAL_BYTES: usize = 1024 * 64;
+    let mut mem_device = Box::new(std::io::Cursor::new(vec![0u8; TOTAL_BYTES]));
+
+    // Create a protective MBR at LBA0
+    let mbr = gpt::mbr::ProtectiveMBR::with_lb_size(
+        u32::try_from(TOTAL_BYTES / 512).unwrap_or(0xFF_FF_FF_FF));
+    mbr.overwrite_lba0(&mut mem_device).unwrap();
+
+    let mut gdisk = gpt::GptConfig::default()
+        .initialized(false)
+        .writable(true)
+        .logical_block_size(disk::LogicalBlockSize::Lb512)
+        .create_from_device(mem_device, None)
+        .unwrap();
+    // Initialize the headers using a blank partition table
+    gdisk.update_partitions(BTreeMap::<u32, gpt::partition::Partition>::new()).unwrap();
+    // At this point, gdisk.primary_header() and gdisk.backup_header() are populated...
+    // Add a few partitions to demonstrate how...
+    gdisk.add_partition("test1", 1024 * 12, gpt::partition_types::BASIC, 0).unwrap();
+    gdisk.add_partition("test2", 1024 * 18, gpt::partition_types::LINUX_FS, 0).unwrap();
+    let mut mem_device = gdisk.write().unwrap();
+    mem_device.seek(std::io::SeekFrom::Start(0)).unwrap();
+    let mut final_bytes = vec![0u8; TOTAL_BYTES];
+    mem_device.read_exact(&mut final_bytes).unwrap();
+}
+
+fn t_read_bytes(device: &mut gpt::DiskDeviceObject, offset: u64, bytes: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; bytes];
+    device.seek(std::io::SeekFrom::Start(offset)).unwrap();
+    device.read_exact(&mut buf).unwrap();
+    buf
+}
+
+fn test_helper_gptdisk_write_efi_unused_partition_entries(lb_size: disk::LogicalBlockSize) {
+    // Test that we write zeros to unused areas of the partition array, so that
+    // if we're creating a partition table from scratch (not loading an existing
+    // table and modifying it) it will create a partition array that is UEFI
+    // compliant (has 128 entries) and unused entries are properly initialized
+    // with zeros.
+
+    let lb_bytes: u64 = lb_size.into();
+    let lb_bytes_usize = lb_bytes as usize;
+    // protective MBR + GPT header + GPT partition array
+    let header_lbs = 1 + 1 + ((128 * 128) / lb_bytes);
+    assert_eq!((128 * 128) % lb_bytes, 0);
+    let data_lbs = 10;
+    // GPT partition array + GPT header
+    let footer_lbs = ((128 * 128) / lb_bytes) + 1;
+    let total_lbs = header_lbs + data_lbs + footer_lbs;
+    let total_bytes = (total_lbs * lb_bytes) as usize;
+
+    // Initialize the buffer with all '255' values so we can tell what's been overwritten vs preserved.
+    let mem_device = Box::new(std::io::Cursor::new(vec![255u8; total_bytes]));
+
+    // Setup a new partition table and add a couple entries to it.
+    let mut gdisk = gpt::GptConfig::default()
+        .initialized(false)
+        .writable(true)
+        .logical_block_size(lb_size)
+        .create_from_device(mem_device, None)
+        .unwrap();
+    // Initialize the headers using a blank partition table.
+    gdisk.update_partitions(BTreeMap::<u32, gpt::partition::Partition>::new()).unwrap();
+
+    let part1_bytes = 3 * lb_bytes;
+    gdisk.add_partition("test1", part1_bytes, gpt::partition_types::BASIC, 0).unwrap();
+    gdisk.add_partition("test2", (data_lbs * lb_bytes) - part1_bytes, gpt::partition_types::LINUX_FS, 0).unwrap();
+
+    // Write out the table and get back the memory buffer so we can validate its contents.
+    let mut mem_device = gdisk.write().unwrap();
+    // Should NOT have overwritten the MBR (we have to generate a protective MBR explicitly using mbr module)
+    assert_eq!(t_read_bytes(&mut mem_device, 0, lb_bytes_usize), vec![255u8; lb_bytes_usize]);
+    // Should have overwritten the header
+    assert_ne!(t_read_bytes(&mut mem_device, lb_bytes, 92), vec![255u8; 92]);
+    // According to the spec, the rest of the sector containing the header should be zeros.
+    assert_eq!(t_read_bytes(&mut mem_device, lb_bytes + 92, lb_bytes_usize - 92), vec![0u8; lb_bytes_usize - 92]);
+    // The first two partition entries should have been overwritten with non-zero data.
+    let first_two = t_read_bytes(&mut mem_device, 2 * lb_bytes, 128 * 2);
+    assert_ne!(first_two, vec![255u8; 128 * 2]);
+    assert_ne!(first_two, vec![0u8; 128 * 2]);
+    // The remaining entries should have been overwritten with all zeros.
+    assert_eq!(t_read_bytes(&mut mem_device, (2 * lb_bytes) + (128 * 2), 126 * 128), vec![0u8; 126 * 128]);
+
+    // The data area should be completely undisturbed...
+    let data_bytes = (data_lbs as usize) * lb_bytes_usize;
+    assert_eq!(t_read_bytes(&mut mem_device, header_lbs * lb_bytes, data_bytes), vec![255u8; data_bytes]);
+
+    // The first two partition entries in the volume footer should have been overwritten with non-zero data.
+    // The remaining entries should have been overwritten with all zeros.
+    let first_two = t_read_bytes(&mut mem_device, (header_lbs + data_lbs) * lb_bytes, 128 * 2);
+    assert_ne!(first_two, vec![255u8; 128 * 2]);
+    assert_ne!(first_two, vec![0u8; 128 * 2]);
+    // The remaining entries should have been overwritten with all zeros.
+    assert_eq!(t_read_bytes(&mut mem_device, (2 * lb_bytes) + (128 * 2), 126 * 128), vec![0u8; 126 * 128]);
+
+    // Should have overwritten the backup header
+    assert_ne!(t_read_bytes(&mut mem_device, total_bytes as u64 - lb_bytes, 92), vec![255u8; 92]);
+    // Remainder of the sector with the backup header should be all zeros
+    assert_eq!(t_read_bytes(&mut mem_device, total_bytes as u64 - lb_bytes + 92, lb_bytes_usize - 92), vec![0u8; lb_bytes_usize - 92]);
+}
+
+#[test]
+fn test_gptdisk_write_efi_unused_partition_entries_512() {
+    test_helper_gptdisk_write_efi_unused_partition_entries(disk::LogicalBlockSize::Lb512);
+}
+
+#[test]
+fn test_gptdisk_write_efi_unused_partition_entries_4096() {
+    test_helper_gptdisk_write_efi_unused_partition_entries(disk::LogicalBlockSize::Lb4096);
 }

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -107,7 +107,7 @@ fn test_create_simple_on_device() {
 
     // Create a protective MBR at LBA0
     let mbr = gpt::mbr::ProtectiveMBR::with_lb_size(
-        u32::try_from(TOTAL_BYTES / 512).unwrap_or(0xFF_FF_FF_FF));
+        u32::try_from((TOTAL_BYTES / 512) - 1).unwrap_or(0xFF_FF_FF_FF));
     mbr.overwrite_lba0(&mut mem_device).unwrap();
 
     let mut gdisk = gpt::GptConfig::default()


### PR DESCRIPTION
Builds on the work done in Quyzi#51. The primary enhancement in this PR is that `GptDisk`, `Partition`, and `ProtectiveMBR` can now work with anything that implements the `Read + Write + Seek + Debug` traits, instead of just a `File`.

It also greatly improves compatibility of GPT partition tables that are created from scratch (rather than modifying an existing GPT partition table in a previous device/image file), e.g., the partition array on disk will be at least 128 entries and unused entries are zero-filled. 

New tests were added to exercise the new generic device support (e.g., writing/reading to/from a memory buffer) as well as creating a GPT table completely from scratch. A test was also added that if we write what we read from an existing disk image and then read it back, that we wrote out things correctly. An example was added to the module doc showing how to create a table from scratch.

Mostly but not completely backwards-compatible from a typing perspective (mainly the return type of the `GptDisk::write` method), so the major version of the crate should get bumped before being released.

Most easily reviewed one commit at a time. Feedback welcome!

Resolves Quyzi#50. Resolves Quyzi#53. Resolves Quyzi#54.

Other minor enhancements/bugfixes in this PR:
 * Ability to convert `u64` to `LogicalBlockSize` (useful if size is specified from program input)
 * Ability to convert a partition type name to partition type (for a similar reason)
 * `GptDisk::write` now writes the partition array that precedes the backup header (previously, it was unchanged!)
 * The disk UUID can optionally be specified when creating a partition table from scratch
 * The default first usable sector needs to consider the sector size, rather than being hard-coded to 34
 * Math fixed for last usable sector when constructing tables from scratch with the 4096 byte sector size
 * Expose partition entries in `ProtectiveMBR` and make `mbr::PartRecord` fields `pub` (enables the crate to be useful for manipulating MBR partition tables in general, not just to generate the protective MBR)
 * Clarify that `ProtectiveMBR::with_lb_size` should be given the size of the protective partition (in sectors), rather than the size of the disk (in sectors)
