### PR TITLE
Update version of the crate and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpt"
-version = "1.0.0"
+version = "2.0.0"
 description = "A pure-Rust library to work with GPT partition tables."
 documentation = "https://docs.rs/gpt"
 authors = ["Chris Ober <obercgit@gmail.com>", "Chris Holcombe <xfactor973@gmail.com>", "Luca Bruno <lucab@debian.org>"]
@@ -12,7 +12,7 @@ edition = "2018"
 bitflags = "~1.2"
 crc = "~1.8"
 log = "~0.4"
-uuid = { version = "~0.7", features = ["v4"] }
+uuid = { version = "~0.8", features = ["v4"] }
 
 [dev-dependencies]
 simplelog = "~0.8"

--- a/src/header.rs
+++ b/src/header.rs
@@ -7,7 +7,6 @@ use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
 use std::path::Path;
-use uuid;
 
 use crate::disk;
 use crate::partition;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -13,7 +13,6 @@ use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::str::FromStr;
-use uuid;
 
 use crate::disk;
 use crate::header::{parse_uuid, Header};


### PR DESCRIPTION
Update the crate to 2.0.0 because of the size of the last update. Also updating the dependencies for `uuid`, `simplelog`, and `tempfile`