### PR TITLE
Allow for creating custom partition tables

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -52,6 +52,7 @@ impl Header {
         backup_offset: u64,
         original_header: &Option<Header>,
         lb_size: disk::LogicalBlockSize,
+        num_parts: Option<u32>,
     ) -> Result<Self> {
         let (cur, bak) = if primary {
             (1, backup_offset)
@@ -64,9 +65,14 @@ impl Header {
         // UEFI requires space for 128 minimum, but the number can be increased or reduced.
         // If we're creating the table from scratch, make sure the table contains enough
         // room to be UEFI compliant.
-        let num_parts = match original_header {
-            Some(header) => header.num_parts,
-            None => (pp.iter().filter(|p| p.1.is_used()).count() as u32).max(128),
+        let num_parts = match num_parts {
+            Some(p) => p,
+            None => {
+                match original_header {
+                    Some(header) => header.num_parts,
+                    None => (pp.iter().filter(|p| p.1.is_used()).count() as u32).max(128),
+                }
+            }
         };
         //though usually 128, it might be a different number
         let part_size = match original_header {
@@ -445,7 +451,7 @@ pub fn write_header(
         }
     };
 
-    let hdr = Header::compute_new(true, &BTreeMap::new(), guid, bak, &None, sector_size)?;
+    let hdr = Header::compute_new(true, &BTreeMap::new(), guid, bak, &None, sector_size, None)?;
     debug!("new header: {:#?}", hdr);
     hdr.write_primary(&mut file, sector_size)?;
 
@@ -482,10 +488,10 @@ fn test_compute_new_fdisk_no_header() {
         }
     };
     let new_primary =
-        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
+        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size, None).unwrap();
     println!("new primary header {:#?}", new_primary);
     let new_backup =
-        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
+        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size, None).unwrap();
     println!("new backup header {:#?}", new_backup);
     new_primary
         .write_primary(&mut tempdisk, lb_size)
@@ -557,6 +563,7 @@ fn test_compute_new_fdisk_pass_header() {
         bak,
         &Some(h.clone()),
         disk::DEFAULT_SECTOR_SIZE,
+        None,
     )
     .unwrap();
     println!("new primary header {:#?}", new_primary);
@@ -567,6 +574,7 @@ fn test_compute_new_fdisk_pass_header() {
         bak,
         &Some(h.clone()),
         disk::DEFAULT_SECTOR_SIZE,
+        None,
     )
     .unwrap();
     println!("new backup header {:#?}", new_backup);
@@ -627,10 +635,10 @@ fn test_compute_new_gpt_no_header() {
         }
     };
     let new_primary =
-        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
+        Header::compute_new(true, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size, None).unwrap();
     println!("new primary header {:#?}", new_primary);
     let new_backup =
-        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size).unwrap();
+        Header::compute_new(false, &partitions, uuid::Uuid::new_v4(), bak, &None, lb_size, None).unwrap();
     println!("new backup header {:#?}", new_backup);
     new_primary
         .write_primary(&mut tempdisk, lb_size)
@@ -702,6 +710,7 @@ fn test_compute_new_fdisk_gpt_header() {
         bak,
         &Some(h.clone()),
         disk::DEFAULT_SECTOR_SIZE,
+        None,
     )
     .unwrap();
     println!("new primary header {:#?}", new_primary);
@@ -712,6 +721,7 @@ fn test_compute_new_fdisk_gpt_header() {
         bak,
         &Some(h.clone()),
         disk::DEFAULT_SECTOR_SIZE,
+        None,
     )
     .unwrap();
     println!("new backup header {:#?}", new_backup);


### PR DESCRIPTION
Primarily intended to be used for embedded systems, since they may require a different partition count.