### PR TITLE
Don't crash on unknown partition types.

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -292,9 +292,7 @@ pub fn file_read_partitions<D: Read + Seek>(
 
             let partname = read_part_name(&mut Cursor::new(&nameraw[..]))?;
             let p = Partition {
-                part_type_guid: Type::from_uuid(&type_guid).map_err(|e| {
-                    Error::new(ErrorKind::Other, format!("Unknown Partition Type: {}", e))
-                })?,
+                part_type_guid: Type::from_uuid(&type_guid).unwrap_or_default(),
                 part_guid,
                 first_lba: u64::from_le_bytes(read_exact_buff!(flba, reader, 8)),
                 last_lba: u64::from_le_bytes(read_exact_buff!(llba, reader, 8)),

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -120,6 +120,12 @@ impl Type {
     }
 }
 
+impl Default for Type {
+    fn default() -> Type {
+        Type { guid: "00000000-0000-0000-0000-000000000000", os: OperatingSystem::None }
+    }
+}
+
 partition_types! {
     /// unused
     (UNUSED, "00000000-0000-0000-0000-000000000000", OperatingSystem::None),


### PR DESCRIPTION
If the partition type is not known then lets make it resort to a default value instead of crashing.

My Android device seems to have a partition type which isn't in the list of known types.