### PR TITLE
Relax `Path` parameter to `impl AsRef<Path>`

### DIFF
--- a/examples/inspect.rs
+++ b/examples/inspect.rs
@@ -20,9 +20,8 @@ fn run() -> io::Result<()> {
     let input = std::env::args().nth(1).unwrap_or(sample);
 
     // Open disk image.
-    let diskpath = std::path::Path::new(&input);
     let cfg = gpt::GptConfig::new().writable(false);
-    let disk = cfg.open(diskpath)?;
+    let disk = cfg.open(input)?;
 
     // Print GPT layout.
     println!("Disk (primary) header: {:#?}", disk.primary_header());

--- a/src/disk.rs
+++ b/src/disk.rs
@@ -61,11 +61,10 @@ impl fmt::Display for LogicalBlockSize {
 /// ## Example
 ///
 /// ```rust,no_run
-/// let diskpath = std::path::Path::new("/dev/sdz");
-/// let gpt_disk = gpt::disk::read_disk(diskpath).unwrap();
+/// let gpt_disk = gpt::disk::read_disk("/dev/sdz").unwrap();
 /// println!("{:#?}", gpt_disk);
 /// ```
-pub fn read_disk(diskpath: &path::Path) -> io::Result<GptDisk> {
+pub fn read_disk(diskpath: impl AsRef<path::Path>) -> io::Result<GptDisk<'static>> {
     let cfg = GptConfig::new();
     cfg.open(diskpath)
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -296,7 +296,10 @@ impl fmt::Display for Header {
 ///
 /// let h = read_header(diskpath, lb_size).unwrap();
 /// ```
-pub fn read_header(path: &Path, sector_size: disk::LogicalBlockSize) -> Result<Header> {
+pub fn read_header(
+    path: impl AsRef<Path>,
+    sector_size: disk::LogicalBlockSize
+) -> Result<Header> {
     let mut file = File::open(path)?;
     read_primary_header(&mut file, sector_size)
 }
@@ -450,11 +453,11 @@ pub(crate) fn partentry_checksum<D: Read + Seek>(
 // TODO: Move this to Header::new() and Header::write to write it
 // that will match the Partition::write() API
 pub fn write_header(
-    p: &Path,
+    p: impl AsRef<Path>,
     uuid: Option<uuid::Uuid>,
     sector_size: disk::LogicalBlockSize,
 ) -> Result<uuid::Uuid> {
-    debug!("opening {} for writing", p.display());
+    debug!("opening {} for writing", p.as_ref().display());
     let mut file = OpenOptions::new().write(true).read(true).open(p)?;
     let bak = find_backup_lba(&mut file, sector_size)?;
     let guid = match uuid {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl GptConfig {
 
     /// Open the GPT disk at the given path and inspect it according
     /// to configuration options.
-    pub fn open(self, diskpath: &path::Path) -> io::Result<GptDisk> {
+    pub fn open(self, diskpath: impl AsRef<path::Path>) -> io::Result<GptDisk<'static>> {
         let file = Box::new(fs::OpenOptions::new()
             .write(self.writable)
             .read(true)

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -248,11 +248,11 @@ fn read_part_name(rdr: &mut Cursor<&[u8]>) -> Result<String> {
 /// println!("{:#?}", partitions);
 /// ```
 pub fn read_partitions(
-    path: &Path,
+    path: impl AsRef<Path>,
     header: &Header,
     lb_size: disk::LogicalBlockSize,
 ) -> Result<BTreeMap<u32, Partition>> {
-    debug!("reading partitions from file: {}", path.display());
+    debug!("reading partitions from file: {}", path.as_ref().display());
     let mut file = File::open(path)?;
     file_read_partitions(&mut file, header, lb_size)
 }


### PR DESCRIPTION
When trying to store `GptDisk` in a struct which was created from a `Path` the following error occurs.
```rust
error[E0597]: `path` does not live long enough
   --> src/main.rs:240:10
    |
238 |           let disk = GptConfig::new()
    |  ____________________-
239 | |             .writable(false)
240 | |             .open(&path)?;
    | |___________________^^^^^- argument requires that `path` is borrowed for `'static`
    |                     |
    |                     borrowed value does not live long enough
...
243 |       }
    |       - `path` dropped here while still borrowed

```
Making `GptDisk<'static>` the return type fixes this.

Additionally i propose to update the parameter `Path` to also accept a `str` like the std library does.