### PR TITLE
Fix partition length undercount (Address #64)

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -166,11 +166,15 @@ impl Partition {
     }
 
     /// Return the length (in bytes) of this partition.
+    /// Partition size is calculated as (last_lba + 1 - first_lba) * block_size
+    /// Bounds are inclusive, meaning we add one to account for the full last logical block
     pub fn bytes_len(&self, lb_size: disk::LogicalBlockSize) -> Result<u64> {
         let len = self
             .last_lba
             .checked_sub(self.first_lba)
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition length underflow - sectors"))?
+            .checked_add(1)
+            .ok_or_else(|| Error::new(ErrorKind::Other, "partition length overflow - sectors"))?
             .checked_mul(lb_size.into())
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition length overflow - bytes"))?;
         Ok(len)


### PR DESCRIPTION
@phil-opp accurately pointed out an issue (#64) with consistent partition-size undercounts, where the space of the last logical block was not taken into account.

This PR does a `checked_add` of 1 to handle this. 