### PR TITLE
Support arbitrary alignment for adding partitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpt"
-version = "2.0.0"
+version = "2.0.1"
 description = "A pure-Rust library to work with GPT partition tables."
 documentation = "https://docs.rs/gpt"
 authors = ["Chris Ober <obercgit@gmail.com>", "Chris Holcombe <xfactor973@gmail.com>", "Luca Bruno <lucab@debian.org>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,8 +241,6 @@ impl<'a> GptDisk<'a> {
         // Find the lowest lba that is larger than size.
         let free_sections = self.find_free_sectors();
         for (starting_lba, length) in free_sections {
-            debug!("starting_lba {}, length {}", starting_lba, length);
-
             // Get the distance between the starting LBA of this section and the next aligned LBA
             // We don't need to do any checked math here because we guarantee that with `(A % B)`,
             // `A` will always be between 0 and `B-1`.
@@ -250,6 +248,8 @@ impl<'a> GptDisk<'a> {
                 Some(alignment) => (alignment - (starting_lba % alignment)) % alignment,
                 None => 0_u64,
             };
+
+            debug!("starting_lba {}, length {}, alignment_offset_lba {}", starting_lba, length, alignment_offset_lba);
 
             if length >= (alignment_offset_lba + size_lba - 1) {
                 let starting_lba= starting_lba + alignment_offset_lba;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -351,8 +351,12 @@ mod tests {
             let b512len = p0.bytes_len(disk::LogicalBlockSize::Lb512).unwrap();
             let b4096len = p0.bytes_len(disk::LogicalBlockSize::Lb4096).unwrap();
 
-            assert_eq!(b512len, 0);
-            assert_eq!(b4096len, 0);
+            // The lower bound of partition size is equal to the logical block size.
+            // This is because the bounds for the partition size are inclusive and use
+            // logical block addressing, meaning that even when the lba_start and lba_end
+            // are set to the same block, you still have the space within that block.
+            assert_eq!(b512len, 512);
+            assert_eq!(b4096len, 4096);
         }
 
         {
@@ -375,7 +379,7 @@ mod tests {
             // Positive value.
             let mut p3 = partition::Partition::zero();
             p3.first_lba = 2;
-            p3.last_lba = 4;
+            p3.last_lba = 3;
             let b512len = p3.bytes_len(disk::LogicalBlockSize::Lb512).unwrap();
             let b4096len = p3.bytes_len(disk::LogicalBlockSize::Lb4096).unwrap();
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -166,11 +166,15 @@ impl Partition {
     }
 
     /// Return the length (in bytes) of this partition.
+    /// Partition size is calculated as (last_lba + 1 - first_lba) * block_size
+    /// Bounds are inclusive, meaning we add one to account for the full last logical block
     pub fn bytes_len(&self, lb_size: disk::LogicalBlockSize) -> Result<u64> {
         let len = self
             .last_lba
             .checked_sub(self.first_lba)
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition length underflow - sectors"))?
+            .checked_add(1)
+            .ok_or_else(|| Error::new(ErrorKind::Other, "partition length overflow - sectors"))?
             .checked_mul(lb_size.into())
             .ok_or_else(|| Error::new(ErrorKind::Other, "partition length overflow - bytes"))?;
         Ok(len)

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -53,7 +53,7 @@ fn test_gptdisk_linux_01() {
     let p1_start = p1.bytes_start(*gdisk.logical_block_size()).unwrap();
     assert_eq!(p1_start, 0x22 * 512);
     let p1_len = p1.bytes_len(*gdisk.logical_block_size()).unwrap();
-    assert_eq!(p1_len, (0x3E - 0x22) * 512);
+    assert_eq!(p1_len, (0x3E - 0x22 + 1) * 512);
 }
 
 #[test]

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -120,8 +120,8 @@ fn test_create_simple_on_device() {
     gdisk.update_partitions(BTreeMap::<u32, gpt::partition::Partition>::new()).unwrap();
     // At this point, gdisk.primary_header() and gdisk.backup_header() are populated...
     // Add a few partitions to demonstrate how...
-    gdisk.add_partition("test1", 1024 * 12, gpt::partition_types::BASIC, 0).unwrap();
-    gdisk.add_partition("test2", 1024 * 18, gpt::partition_types::LINUX_FS, 0).unwrap();
+    gdisk.add_partition("test1", 1024 * 12, gpt::partition_types::BASIC, 0, None).unwrap();
+    gdisk.add_partition("test2", 1024 * 18, gpt::partition_types::LINUX_FS, 0, None).unwrap();
     let mut mem_device = gdisk.write().unwrap();
     mem_device.seek(std::io::SeekFrom::Start(0)).unwrap();
     let mut final_bytes = vec![0u8; TOTAL_BYTES];
@@ -167,8 +167,8 @@ fn test_helper_gptdisk_write_efi_unused_partition_entries(lb_size: disk::Logical
     gdisk.update_partitions(BTreeMap::<u32, gpt::partition::Partition>::new()).unwrap();
 
     let part1_bytes = 3 * lb_bytes;
-    gdisk.add_partition("test1", part1_bytes, gpt::partition_types::BASIC, 0).unwrap();
-    gdisk.add_partition("test2", (data_lbs * lb_bytes) - part1_bytes, gpt::partition_types::LINUX_FS, 0).unwrap();
+    gdisk.add_partition("test1", part1_bytes, gpt::partition_types::BASIC, 0, None).unwrap();
+    gdisk.add_partition("test2", (data_lbs * lb_bytes) - part1_bytes, gpt::partition_types::LINUX_FS, 0, None).unwrap();
 
     // Write out the table and get back the memory buffer so we can validate its contents.
     let mut mem_device = gdisk.write().unwrap();


### PR DESCRIPTION
Adds alignment to an arbitrary number of blocks when adding partitions. Creating partitions without this can hurt disk read performance, especially for disks with larger page sizes. I was worried about being too opinionated in adding this, so I opted not to add any notion of default alignments as it's entirely dependent on the unknown disk page size. 

See also: https://en.wikipedia.org/wiki/Advanced_Format

This isn't cherry picked out of my other changes as it needs #72 in addition to the fix for size undercounting from floored division. Probably best to merge #72 first and then merge this? 