### PR TITLE
Support custom partition GUIDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 bitflags = "^1.2"
 crc = "^1.8"
 log = "^0.4"
-uuid = { version = "^0.8", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 simplelog = "^0.8"

--- a/src/header.rs
+++ b/src/header.rs
@@ -257,22 +257,17 @@ impl Header {
 
 /// Parses a uuid with first 3 portions in little endian.
 pub fn parse_uuid(rdr: &mut Cursor<&[u8]>) -> Result<uuid::Uuid> {
-    let d1: u32 = u32::from_le_bytes(read_exact_buff!(d1b, rdr, 4));
-    let d2: u16 = u16::from_le_bytes(read_exact_buff!(d2b, rdr, 2));
-    let d3: u16 = u16::from_le_bytes(read_exact_buff!(d3b, rdr, 2));
-    use std::convert::TryInto;
-    let pos = rdr.position() as usize;
-    let d4 = match rdr.get_ref()[pos..pos + 8].try_into() {
-        Ok(d4) => d4,
-        Err(_) => return Err(Error::new(ErrorKind::Other, "Invalid Disk UUID?")),
-    };
+    let d1 = u32::from_le_bytes(read_exact_buff!(d1b, rdr, 4));
+    let d2 = u16::from_le_bytes(read_exact_buff!(d2b, rdr, 2));
+    let d3 = u16::from_le_bytes(read_exact_buff!(d3b, rdr, 2));
+    let d4 = read_exact_buff!(d4b, rdr, 8);
+
     let uuid = uuid::Uuid::from_fields(
         d1,
         d2,
         d3,
-        d4,
+        &d4,
     );
-    rdr.seek(SeekFrom::Current(8))?;
     Ok(uuid)
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -260,18 +260,20 @@ pub fn parse_uuid(rdr: &mut Cursor<&[u8]>) -> Result<uuid::Uuid> {
     let d1: u32 = u32::from_le_bytes(read_exact_buff!(d1b, rdr, 4));
     let d2: u16 = u16::from_le_bytes(read_exact_buff!(d2b, rdr, 2));
     let d3: u16 = u16::from_le_bytes(read_exact_buff!(d3b, rdr, 2));
+    use std::convert::TryInto;
+    let pos = rdr.position() as usize;
+    let d4 = match rdr.get_ref()[pos..pos + 8].try_into() {
+        Ok(d4) => d4,
+        Err(_) => return Err(Error::new(ErrorKind::Other, "Invalid Disk UUID?")),
+    };
     let uuid = uuid::Uuid::from_fields(
         d1,
         d2,
         d3,
-        &rdr.get_ref()[rdr.position() as usize..rdr.position() as usize + 8],
+        d4,
     );
     rdr.seek(SeekFrom::Current(8))?;
-
-    match uuid {
-        Ok(uuid) => Ok(uuid),
-        Err(_) => Err(Error::new(ErrorKind::Other, "Invalid Disk UUID?")),
-    }
+    Ok(uuid)
 }
 
 impl fmt::Display for Header {
@@ -372,7 +374,7 @@ pub(crate) fn file_read_header<D: Read + Seek>(file: &mut D, offset: u64) -> Res
         crc32_parts: u32::from_le_bytes(read_exact_buff!(crc32parts, reader, 4)),
     };
     trace!("header: {:?}", &hdr[..]);
-    trace!("header gpt: {}", h.disk_guid.to_hyphenated().to_string());
+    trace!("header gpt: {}", h.disk_guid.as_hyphenated().to_string());
     let mut hdr_crc = hdr;
     for crc_byte in hdr_crc.iter_mut().skip(16).take(4) {
         *crc_byte = 0;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,7 +28,13 @@ pub mod pub_macros {
             let res_u = Uuid::try_parse(s);
             match res_u {
                 Ok(u) => return u,
-                Err(_) => ::std::panic!("string was not an uuid"),
+                Err(_) => {
+                    // const_panic requires 1.57
+                    #[allow(unconditional_panic)]
+                    ["string was not an uuid"][1];
+                    // never type
+                    loop {}
+                },
             }
         }
         $(
@@ -51,30 +57,25 @@ pub mod pub_macros {
                         match ::uuid::Uuid::from_str(s) {
                             Ok(u) => Ok(Type {
                                 guid: u,
-                                os: OperatingSystem::Custom("Unknown".to_owned()),
+                                os: OperatingSystem::None,
                             }),
-                            Err(_) => Err("Can't match: not a valid UUID or unknown partition type".to_string()),
+                            Err(_) => Err("Invalid Partition Type GUID.".to_string()),
                         }
                     }
                 }
             }
         }
-        impl From<&Uuid> for Type {
-            fn from(u: &Uuid) -> Self {
+        impl From<Uuid> for Type {
+            fn from(guid: Uuid) -> Self {
                 $(
-                    if u == &$upcase.guid {
+                    if guid == $upcase.guid {
                         return $upcase;
                     }
                 )+
                 Type {
-                    guid: *u,
-                    os: OperatingSystem::Custom("Unknown".to_owned()),
+                    guid,
+                    os: OperatingSystem::None,
                 }
-            }
-        }
-        impl From<Uuid> for Type {
-            fn from(u: Uuid) -> Self {
-                (&u).into()
             }
         }
     }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -292,7 +292,7 @@ pub fn file_read_partitions<D: Read + Seek>(
 
             let partname = read_part_name(&mut Cursor::new(&nameraw[..]))?;
             let p = Partition {
-                part_type_guid: Type::from_uuid(&type_guid).unwrap_or_default(),
+                part_type_guid: type_guid.into(),
                 part_guid,
                 first_lba: u64::from_le_bytes(read_exact_buff!(flba, reader, 8)),
                 last_lba: u64::from_le_bytes(read_exact_buff!(llba, reader, 8)),

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -12,7 +12,6 @@ use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Cursor, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::str::FromStr;
 
 use crate::disk;
 use crate::header::{parse_uuid, Header};
@@ -66,9 +65,7 @@ impl Partition {
         let mut buf: Vec<u8> = Vec::with_capacity(entry_size as usize);
 
         // Type GUID.
-        let tyguid = uuid::Uuid::from_str(self.part_type_guid.guid).map_err(|e| {
-            Error::new(ErrorKind::Other, format!("Invalid guid: {}", e.to_string()))
-        })?;
+        let tyguid = &self.part_type_guid.guid;
         let tyguid = tyguid.as_fields();
         buf.write_all(&tyguid.0.to_le_bytes())?;
         buf.write_all(&tyguid.1.to_le_bytes())?;

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -106,11 +106,6 @@ fn test_partition_from_name() {
 }
 
 impl Type {
-    /// Lookup a partition type by uuid
-    pub fn from_uuid(u: &uuid::Uuid) -> Result<Self, String> {
-        Ok(u.into())
-    }
-
     /// Lookup a partition type by name
     pub fn from_name(name: &str) -> Result<Self, String> {
         let name_str = name.to_uppercase();

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -1,12 +1,13 @@
 //! Parition type constants
 use log::trace;
 use std::str::FromStr;
+use ::uuid::Uuid;
 
 /// The type
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Type {
     /// Type-GUID for a GPT partition.
-    pub guid: &'static str,
+    pub guid: Uuid,
     /// well-known OS label for this type-GUID.
     pub os: OperatingSystem,
 }
@@ -107,9 +108,7 @@ fn test_partition_from_name() {
 impl Type {
     /// Lookup a partition type by uuid
     pub fn from_uuid(u: &uuid::Uuid) -> Result<Self, String> {
-        let uuid_str = u.to_hyphenated().to_string().to_uppercase();
-        trace!("looking up partition type guid {}", uuid_str);
-        Type::from_str(&uuid_str)
+        Ok(u.into())
     }
 
     /// Lookup a partition type by name
@@ -122,7 +121,7 @@ impl Type {
 
 impl Default for Type {
     fn default() -> Type {
-        Type { guid: "00000000-0000-0000-0000-000000000000", os: OperatingSystem::None }
+        UNUSED
     }
 }
 


### PR DESCRIPTION
**Provides:**  
Support to specify and read partition UUID that are not hardcoded in the library

**Motivation:**  
I am writing a tool that needs to handle gpt in the most general way possible, I can't really limit myself to a few partition types.

**How:**  
The problem is `partition_type::Type`, which contains `pub guid: &'static str,`.  
This can't support anything non-hardcoded. The solution is either to keep trying to use `&str` and play around with lifetimes and hide allocations somewhere in ugly ways, or just use `String`

At that point the macro is modified so that instead of generating `const NAME : Type` it generates `fn NAME() -> Type` which allocates the string for the guid on the heap.

The macro will return a Type as before, but when called with an unknown UUID it will set the `os` to `Unknown`, and will return error only if it receives a string that is not a uuid or a valid name

Is this good enough or do you prefer other approaches?

**TODO:**  
before merging:
* tests pass, compiles and I think it's faily safe, but I have *NOT* actually tested the result (need more time, meanwhile please comment)
* the signature of `partition_type::Type` has changed, therefore this needs a semversion bump (not included)

-----
P.S.: can I suggest also enabling `rustfmt` in your editor of choice?