### PR TITLE
Fix and improve sector length calculation

### DIFF
--- a/src/disk.rs
+++ b/src/disk.rs
@@ -1,7 +1,7 @@
 //! Disk-related types and helper functions.
 
 use super::{GptConfig, GptDisk, GptError};
-use std::{convert::TryFrom, fmt, fs, io, path};
+use std::{fmt, fs, io, path};
 
 /// Default size of a logical sector (bytes).
 pub const DEFAULT_SECTOR_SIZE: LogicalBlockSize = LogicalBlockSize::Lb512;

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -6,7 +6,6 @@
 use bitflags::*;
 use crc::Crc;
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};


### PR DESCRIPTION
This mixes a few things:

* Take partition length being an inclusive range into account (fixes #96)
* Rename size to sectors_len: This makes it consistent with bytes_len naming and more clear of what it returns
* Make bytes_len use sectors_len for the calculation rather then re-implementing it
* Expand partition len tests to test for both sectors and byte length