### PR TITLE
better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 	"Sören Meier <s@renmeier.ch>",
 ]
 license = "MIT"
-homepage = "https://github.com/Quyzi/gpt"
+repository = "https://github.com/Quyzi/gpt"
 edition = "2021"
 rust-version = "1.65"
 


### PR DESCRIPTION
to allow https://crates.io/ , https://lib.rs/ and https://rust-digger.code-maven.com/ to link to it
See also https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field
