### PR TITLE
compute_alignment() u32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -642,7 +642,7 @@ where
 
         let mut exponent = (align as f64).log2() as u32;
 
-        for (_id, partition) in &self.partitions {
+        for partition in self.partitions.values() {
             if partition.is_used() {
                 let mut found = false;
                 while !found {

--- a/tests/gpt.rs
+++ b/tests/gpt.rs
@@ -74,6 +74,10 @@ fn test_gpt_disk_read() {
     assert_eq!(p2_start, 512 * 35);
     let p2_len = p2.bytes_len(*gdisk.logical_block_size()).unwrap();
     assert_eq!(p2_len, 4 * 512);
+
+    let part_alignment = gdisk.compute_alignment();
+    println!("Test part alignment={}", part_alignment);
+    assert_eq!(part_alignment, 1);
 }
 
 #[test]


### PR DESCRIPTION
Add compute_alignment for a existed gpt disk .In order to promise **_consistent_** part alignment among various gpt libs.
Ported from gptfdisk's gpt.cc. Original document is :
**// Compute sector alignment based on the current partitions (if any). Each
// partition's starting LBA is examined, and if it's divisible by a power-of-2
// value less than or equal to the DEFAULT_ALIGNMENT value (adjusted for the
// sector size), but not by the previously-located alignment value, then the
// alignment value is adjusted down. If the computed alignment is less than 8
// and the disk is bigger than SMALLEST_ADVANCED_FORMAT, resets it to 8. This
// is a safety measure for Advanced Format drives. If no partitions are
// defined, the alignment value is set to DEFAULT_ALIGNMENT (2048) (or an
// adjustment of that based on the current sector size). The result is that new
// drives are aligned to 2048-sector multiples but the program won't complain
// about other alignments on existing disks unless a smaller-than-8 alignment
// is used on big disks (as safety for Advanced Format drives).
// Returns the computed alignment value.**