### PR TITLE
Make partition_types::Type::FromStr case-insensitive for guid

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,7 @@ pub mod pub_macros {
             impl FromStr for Type {
                 type Err = String;
                 fn from_str(s: &str) -> Result<Self, Self::Err> {
-                    match s {
+                    match s.to_ascii_uppercase().as_str() {
                         $(
                             $guid |
                             stringify!($upcase) => Ok($upcase),

--- a/src/partition_types.rs
+++ b/src/partition_types.rs
@@ -352,6 +352,12 @@ mod tests {
             Type::from_str("00000000-0000-0000-0000-000000000000").unwrap(),
             UNUSED
         );
+
+        // test case sensitivity
+        assert_eq!(
+            Type::from_str("ebd0a0a2-b9e5-4433-87c0-68b6b72699c7").unwrap(),
+            BASIC
+        );
     }
 
     #[test]


### PR DESCRIPTION
This does make Type::from_name() kind of redundant. Since now the input will be uppercased twice.

Could remove uppercase call in from_name(), but not sure how you want to handle that change from a logging perspective.