### PR TITLE
update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gpt
 [![crates.io](https://img.shields.io/crates/v/gpt.svg)](https://crates.io/crates/gpt)
-![minimum rust 1.63](https://img.shields.io/badge/rust-1.63%2B-orange.svg)
+![minimum rust 1.65](https://img.shields.io/badge/rust-1.65%2B-orange.svg)
 [![Documentation](https://docs.rs/gpt/badge.svg)](https://docs.rs/gpt)
 
 A pure-Rust library to work with GPT partition tables.
@@ -11,9 +11,7 @@ tables. It supports any  that implements the `Read + Write + Seek + Debug` trait
 ## Example
 
 ```rust
-use gpt;
-
-use std::io;
+use std::error::Error;
 
 fn main() {
     // Inspect disk image, handling errors.
@@ -23,15 +21,14 @@ fn main() {
     }
 }
 
-fn run() -> io::Result<()> {
+fn run() -> Result<(), Box<dyn Error>> {
     // First parameter is target disk image (optional, default: fixtures sample)
-    let sample = "tests/fixtures/gpt-linux-disk-01.img".to_string();
+    let sample = "tests/fixtures/gpt-disk.img".to_string();
     let input = std::env::args().nth(1).unwrap_or(sample);
 
     // Open disk image.
-    let diskpath = std::path::Path::new(&input);
     let cfg = gpt::GptConfig::new().writable(false);
-    let disk = cfg.open(diskpath)?;
+    let disk = cfg.open(input)?;
 
     // Print GPT layout.
     println!("Disk (primary) header: {:#?}", disk.primary_header());


### PR DESCRIPTION
Noticed some discrepancies in the readme. Most notably the msrv bump 8929bed97983a6e0927a99581982db9ece9dc5ff.

Correct me if I'm wrong here, but it looks like the example is intended to mirror `examples/inspect.rs`. So I just copied that into the readme. It appears that most of the commits changing `examples/inspect.rs` up to (and including) b6861d0c468dc4bd0cf069327df9fccdec705054 were not reflected in the readme